### PR TITLE
Fixed #24: Remember fields unmarked by encoder and force set it if entity is used as a baseline

### DIFF
--- a/rehlds/engine/delta.cpp
+++ b/rehlds/engine/delta.cpp
@@ -735,7 +735,7 @@ qboolean DELTA_CheckDelta(unsigned char *from, unsigned char *to, delta_t *pFiel
 	qboolean sendfields;
 
 #if defined(REHLDS_OPT_PEDANTIC) || defined(REHLDS_FIXES)
-	sendfields = DELTAJit_Fields_Clear_Mark_Check(from, to, pFields);
+	sendfields = DELTAJit_Fields_Clear_Mark_Check(from, to, pFields, NULL);
 #else
 	DELTA_ClearFlags(pFields);
 	DELTA_MarkSendFields(from, to, pFields);
@@ -752,7 +752,7 @@ NOINLINE qboolean DELTA_WriteDelta(unsigned char *from, unsigned char *to, qbool
 	int bytecount;
 
 #if defined(REHLDS_OPT_PEDANTIC) || defined(REHLDS_FIXES)
-	sendfields = DELTAJit_Fields_Clear_Mark_Check(from, to, pFields);
+	sendfields = DELTAJit_Fields_Clear_Mark_Check(from, to, pFields, NULL);
 #else // REHLDS_OPT_PEDANTIC || REHLDS_FIXES
 	DELTA_ClearFlags(pFields);
 	DELTA_MarkSendFields(from, to, pFields);
@@ -762,6 +762,15 @@ NOINLINE qboolean DELTA_WriteDelta(unsigned char *from, unsigned char *to, qbool
 	_DELTA_WriteDelta(from, to, force, pFields, callback, sendfields);
 	return sendfields;
 }
+
+#ifdef REHLDS_FIXES //Fix for https://github.com/dreamstalker/rehlds/issues/24
+qboolean DELTA_WriteDeltaForceMask(unsigned char *from, unsigned char *to, qboolean force, delta_t *pFields, void(*callback)(void), void* pForceMask) {
+	qboolean sendfields = DELTAJit_Fields_Clear_Mark_Check(from, to, pFields, pForceMask);
+	_DELTA_WriteDelta(from, to, force, pFields, callback, sendfields);
+	return sendfields;
+}
+#endif
+
 
 qboolean _DELTA_WriteDelta(unsigned char *from, unsigned char *to, qboolean force, delta_t *pFields, void(*callback)( void ), qboolean sendfields)
 {

--- a/rehlds/engine/delta.h
+++ b/rehlds/engine/delta.h
@@ -139,6 +139,11 @@ void DELTA_SetSendFlagBits(delta_t *pFields, int *bits, int *bytecount);
 qboolean DELTA_IsFieldMarked(delta_t* pFields, int fieldNumber);
 void DELTA_WriteMarkedFields(unsigned char *from, unsigned char *to, delta_t *pFields);
 qboolean DELTA_CheckDelta(unsigned char *from, unsigned char *to, delta_t *pFields);
+
+#ifdef REHLDS_FIXES //Fix for https://github.com/dreamstalker/rehlds/issues/24
+qboolean DELTA_WriteDeltaForceMask(unsigned char *from, unsigned char *to, qboolean force, delta_t *pFields, void(*callback)(void), void* pForceMask);
+#endif
+
 qboolean DELTA_WriteDelta(unsigned char *from, unsigned char *to, qboolean force, delta_t *pFields, void(*callback)(void));
 qboolean _DELTA_WriteDelta(unsigned char *from, unsigned char *to, qboolean force, delta_t *pFields, void(*callback)(void), qboolean sendfields);
 int DELTA_ParseDelta(unsigned char *from, unsigned char *to, delta_t *pFields);

--- a/rehlds/engine/delta_jit.h
+++ b/rehlds/engine/delta_jit.h
@@ -73,8 +73,13 @@ union delta_marked_mask_t {
 
 extern CDeltaJitRegistry g_DeltaJitRegistry;
 
-extern int DELTAJit_Fields_Clear_Mark_Check(unsigned char *from, unsigned char *to, delta_t *pFields);
+extern int DELTAJit_Fields_Clear_Mark_Check(unsigned char *from, unsigned char *to, delta_t *pFields, void* pForceMarkMask);
 extern void DELTAJit_SetSendFlagBits(delta_t *pFields, int *bits, int *bytecount);
 extern void DELTAJit_SetFieldByIndex(struct delta_s *pFields, int fieldNumber);
 extern void DELTAJit_UnsetFieldByIndex(struct delta_s *pFields, int fieldNumber);
 extern qboolean DELTAJit_IsFieldMarked(delta_t* pFields, int fieldNumber);
+
+/* Returns original mask, before it was changed by the conditional encoder */
+extern uint64 DELTAJit_GetOriginalMask(delta_t* pFields);
+
+extern uint64 DELTAJit_GetMaskU64(delta_t* pFields);

--- a/rehlds/unittests/delta_tests.cpp
+++ b/rehlds/unittests/delta_tests.cpp
@@ -64,7 +64,7 @@ NOINLINE qboolean _DoMarkFields(void* src, void* dst, delta_t* delta, bool useJi
 	qboolean sendfields;
 	if (useJit) {
 		DELTA_ClearFlags(delta);
-		return DELTAJit_Fields_Clear_Mark_Check((unsigned char*)src, (unsigned char*)dst, delta);
+		return DELTAJit_Fields_Clear_Mark_Check((unsigned char*)src, (unsigned char*)dst, delta, NULL);
 	} else {
 		DELTA_ClearFlags(delta);
 		DELTA_MarkSendFields((unsigned char*)src, (unsigned char*)dst, delta);


### PR DESCRIPTION
Fixed #24: Remember fields unmarked by encoder and force set it if entity is used as a baseline