### PR TITLE
Implemented SV_WriteFullClientUpdate callback

### DIFF
--- a/rehlds/public/rehlds/rehlds_api.h
+++ b/rehlds/public/rehlds/rehlds_api.h
@@ -137,6 +137,10 @@ typedef IVoidHookChainRegistry<edict_t *> IRehldsHookRegistry_PF_Remove_I;
 typedef IVoidHookChain<edict_t *, int, const char *, float, float, int, int, int, int, const float *, edict_t *> IRehldsHook_PF_BuildSoundMsg_I;
 typedef IVoidHookChainRegistry<edict_t *, int, const char *, float, float, int, int, int, int, const float *, edict_t *> IRehldsHookRegistry_PF_BuildSoundMsg_I;
 
+//SV_WriteFullClientUpdate hook
+typedef IVoidHookChain<IGameClient *, char *, size_t, sizebuf_t *, IGameClient *> IRehldsHook_SV_WriteFullClientUpdate;
+typedef IVoidHookChainRegistry<IGameClient *, char *, size_t, sizebuf_t *, IGameClient *> IRehldsHookRegistry_SV_WriteFullClientUpdate;
+
 class IRehldsHookchains {
 public:
 	virtual ~IRehldsHookchains() { }
@@ -166,6 +170,7 @@ public:
 	virtual IRehldsHookRegistry_SV_StartSound* SV_StartSound() = 0;
 	virtual IRehldsHookRegistry_PF_Remove_I* PF_Remove_I() = 0;
 	virtual IRehldsHookRegistry_PF_BuildSoundMsg_I* PF_BuildSoundMsg_I() = 0;
+	virtual IRehldsHookRegistry_SV_WriteFullClientUpdate* SV_WriteFullClientUpdate() = 0;
 };
 
 struct RehldsFuncs_t {

--- a/rehlds/rehlds/rehlds_api_impl.cpp
+++ b/rehlds/rehlds/rehlds_api_impl.cpp
@@ -249,6 +249,10 @@ IRehldsHookRegistry_PF_BuildSoundMsg_I* CRehldsHookchains::PF_BuildSoundMsg_I() 
 	return &m_PF_BuildSoundMsg_I;
 }
 
+IRehldsHookRegistry_SV_WriteFullClientUpdate* CRehldsHookchains::SV_WriteFullClientUpdate() {
+	return &m_SV_WriteFullClientUpdate;
+}
+
 int EXT_FUNC CRehldsApi::GetMajorVersion()
 {
 	return REHLDS_API_VERSION_MAJOR;

--- a/rehlds/rehlds/rehlds_api_impl.h
+++ b/rehlds/rehlds/rehlds_api_impl.h
@@ -131,6 +131,10 @@ typedef IVoidHookChainRegistryImpl<edict_t *> CRehldsHookRegistry_PF_Remove_I;
 typedef IVoidHookChainImpl<edict_t *, int, const char *, float, float, int, int, int, int, const float *, edict_t *> CRehldsHook_PF_BuildSoundMsg_I;
 typedef IVoidHookChainRegistryImpl<edict_t *, int, const char *, float, float, int, int, int, int, const float *, edict_t *> CRehldsHookRegistry_PF_BuildSoundMsg_I;
 
+//SV_WriteFullClientUpdate hook
+typedef IVoidHookChainImpl<IGameClient *, char *, size_t, sizebuf_t *, IGameClient *> CRehldsHook_SV_WriteFullClientUpdate;
+typedef IVoidHookChainRegistryImpl<IGameClient *, char *, size_t, sizebuf_t *, IGameClient *> CRehldsHookRegistry_SV_WriteFullClientUpdate;
+
 class CRehldsHookchains : public IRehldsHookchains {
 public:
 	CRehldsHookRegistry_Steam_NotifyClientConnect m_Steam_NotifyClientConnect;
@@ -158,6 +162,7 @@ public:
 	CRehldsHookRegistry_SV_StartSound m_SV_StartSound;
 	CRehldsHookRegistry_PF_Remove_I m_PF_Remove_I;
 	CRehldsHookRegistry_PF_BuildSoundMsg_I m_PF_BuildSoundMsg_I;
+	CRehldsHookRegistry_SV_WriteFullClientUpdate m_SV_WriteFullClientUpdate;
 
 public:
 	virtual IRehldsHookRegistry_Steam_NotifyClientConnect* Steam_NotifyClientConnect();
@@ -185,6 +190,7 @@ public:
 	virtual IRehldsHookRegistry_SV_StartSound* SV_StartSound();
 	virtual IRehldsHookRegistry_PF_Remove_I* PF_Remove_I();
 	virtual IRehldsHookRegistry_PF_BuildSoundMsg_I* PF_BuildSoundMsg_I();
+	virtual IRehldsHookRegistry_SV_WriteFullClientUpdate* SV_WriteFullClientUpdate();
 };
 
 extern CRehldsHookchains g_RehldsHookchains;

--- a/rehlds/rehlds/rehlds_interfaces_impl.cpp
+++ b/rehlds/rehlds/rehlds_interfaces_impl.cpp
@@ -205,6 +205,9 @@ void Rehlds_Interfaces_InitClients()
 
 IGameClient* GetRehldsApiClient(client_t* cl)
 {
+	if (cl == NULL)
+		return NULL; //I think it's logical.
+
 	int idx = cl - g_psvs.clients;
 	if (idx < 0 || idx >= g_psvs.maxclients)
 	{


### PR DESCRIPTION
It's my vision of callback that allows to customize sending client's userinfo. But there is a problem, if info is sent to all, for customization we must call SV_WriteFullClientUpdate individually for each client. What's better:
1) Rewrite callNext to allow call it several times from one chain.
2) Write another call next function for this situation.
3) Add api function for SV_WriteFullClientUpdate and use it instead of call next chain.