### PR TITLE
Fix: bug with removing slash in the path to resources

### DIFF
--- a/rehlds/engine/model.cpp
+++ b/rehlds/engine/model.cpp
@@ -279,7 +279,7 @@ model_t *Mod_LoadModel(model_t *mod, qboolean crash, qboolean trackCRC)
 	if (COM_CheckParm("-steam") && mod->name[0] == '/')
 	{
 		char* p = mod->name;
-		while (*(p++) == '/')
+		while (*(++p) == '/')
 			;
 
 		Q_strncpy(tmpName, p, sizeof(tmpName) - 1);


### PR DESCRIPTION
This bug can be reproduced as follows:
The presence of *.res file for the map

de_dust2.res
> /sprites/flame2.spr

thus the removal of slash's with iterator post ++ followed by a delete of the first character in pathname

result:
> prites/flame2.spr