### PR TITLE
Fix: skip bytes BOM signature in SV_CreateGenericResources

### DIFF
--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -4945,7 +4945,12 @@ void SV_CreateGenericResources(void)
 	if (buffer == NULL)
 		return;
 
-	data = buffer;
+	// skip bytes BOM signature
+	if ((byte)buffer[0] == 0xEFu && (byte)buffer[1] == 0xBBu && (byte)buffer[2] == 0xBFu)
+		data = &buffer[3];
+	else
+		data = buffer;
+
 	Con_DPrintf("Precaching from %s\n", filename);
 	Con_DPrintf("----------------------------------\n");
 	g_psv.num_generic_names = 0;


### PR DESCRIPTION
Fixed bug with:
> Host_Error: PF_precache_generic_I: Bad string '// .\de_storm.res - created with RESGen v1.00'

Reason: comments are doesn't ignored in .res files by reason of the signature BOM in header.

Detailed Investigation:
de_storm.res

>// .\de_storm.res - created with RESGen v1.00
// RESGen is made by Jeroen "ShadowLord" Bogers
// URL: http://www.unitedadmins.com/mapRESGEN.asp
// Res creation date, GMT timezone (dd-mm-yyyy): 08-06-2001
>
// .res entries:
de_storm.wad
[... etc]

If .res file saved with BOM signature so we get

Breakpoint from SV_CreateGenericResources:
![bom](https://cloud.githubusercontent.com/assets/5860435/11594872/a390cb02-9ad6-11e5-8365-cbbe2b9d7020.jpg)

> п»ї// .\de_storm.res - created with RESGen v1.00

where      "п»ї"    is    EF BB BF

> 0EF 0BB 0BF 047 047 032 046 092 100 101 095 115 116 111 114 109 046 114 101 115 032 045 032 099 114 101 097 116 101 100 032 119 105 116 104 032 082 069 083 071 101 110 032 118 049 046 048 048

Thus we have to skip BOM signature for correctly ignore comments.
