### PR TITLE
SV_HullForBsp: use hull center instead of corner

### DIFF
--- a/rehlds/engine/server.h
+++ b/rehlds/engine/server.h
@@ -543,6 +543,7 @@ extern cvar_t sv_echo_unknown_cmd;
 extern cvar_t sv_auto_precache_sounds_in_models;
 extern cvar_t sv_delayed_spray_upload;
 extern cvar_t sv_rehlds_force_dlmax;
+extern cvar_t sv_rehlds_hull_centering;
 #endif
 extern int sv_playermodel;
 

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -304,6 +304,7 @@ cvar_t sv_auto_precache_sounds_in_models = { "sv_auto_precache_sounds_in_models"
 cvar_t sv_delayed_spray_upload = { "sv_delayed_spray_upload", "0", 0, 0.0f, nullptr };
 cvar_t sv_rehlds_force_dlmax = { "sv_rehlds_force_dlmax", "0", 0, 0.0f, nullptr };
 cvar_t listipcfgfile = { "listipcfgfile", "listip.cfg", 0, 0.0f, nullptr };
+cvar_t sv_rehlds_hull_centering = { "sv_rehlds_hull_centering", "0", 0, 0.0f, nullptr };
 #endif
 
 /* <a6492> ../engine/sv_main.c:113 */
@@ -7775,6 +7776,7 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_auto_precache_sounds_in_models);
 	Cvar_RegisterVariable(&sv_delayed_spray_upload);
 	Cvar_RegisterVariable(&sv_rehlds_force_dlmax);
+	Cvar_RegisterVariable(&sv_rehlds_hull_centering);
 #endif
 	
 	for (int i = 0; i < MAX_MODELS; i++)

--- a/rehlds/engine/world.cpp
+++ b/rehlds/engine/world.cpp
@@ -190,8 +190,23 @@ struct hull_s *SV_HullForBsp(edict_t *ent, const vec_t *mins, const vec_t *maxs,
 			else
 				hull = &model->hulls[3];
 		}
+// TODO: add cvar for this?
+#ifdef REHLDS_FIXES
+		if (   sv_rehlds_hull_centering.value
+		    && mins[0] + maxs[0] == 0.0f)
+			offset[0] = 0.0f;
+		else
+			offset[0] = hull->clip_mins[0] - mins[0];
+		
+		if (   sv_rehlds_hull_centering.value
+		    && mins[1] + maxs[1] == 0.0f)
+			offset[1] = 0.0f;
+		else
+			offset[1] = hull->clip_mins[1] - mins[1];
+#else // REHLDS_FIXES
 		offset[0] = hull->clip_mins[0] - mins[0];
 		offset[1] = hull->clip_mins[1] - mins[1];
+#endif // REHLDS_FIXES
 		offset[2] = hull->clip_mins[2] - mins[2];
 	}
 	else


### PR DESCRIPTION
If bbox size greater than hull size:
with old code: hull is located in bbox negative corner (-x and -y).
with new code: hull is located in bbox center.