### PR TITLE
Fixed "error C4996: 'GetVersionExA': was declared deprecated" using a crutch.

### DIFF
--- a/rehlds/engine/sys_dll2.cpp
+++ b/rehlds/engine/sys_dll2.cpp
@@ -187,6 +187,8 @@ NOXREF int Sys_IsWin98(void)
 }
 
 #ifdef _WIN32
+#pragma warning( push )  
+#pragma warning( disable : 4996 )  
 NOXREF void Sys_CheckOSVersion(void)
 {
 	struct _OSVERSIONINFOA verInfo;
@@ -210,6 +212,7 @@ NOXREF void Sys_CheckOSVersion(void)
 		}
 	}
 }
+#pragma warning ( pop )
 #endif // _WIN32
 
 void Sys_Init(void)


### PR DESCRIPTION
VS 2013 says:

> 2>d:\rehlds\rehlds\engine\sys_dll2.cpp(196): error C4996: 'GetVersionExA': объявлен deprecate
2>          c:\program files (x86)\windows kits\8.1\include\um\sysinfoapi.h(433): см. объявление "GetVersionExA"