### PR TITLE
Fixed typo in SV_FindModelNumbers

### DIFF
--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -710,7 +710,7 @@ void SV_FindModelNumbers(void)
 
 		// use case-sensitive names to increase performance
 #ifdef REHLDS_FIXES
-		if (!Q_stricmp(g_psv.model_precache[i], "models/player.mdl"))
+		if (!Q_strcmp(g_psv.model_precache[i], "models/player.mdl"))
 			sv_playermodel = i;
 #else
 		if (!Q_stricmp(g_psv.model_precache[i], "models/player.mdl"))


### PR DESCRIPTION
Typo from [this commit](https://github.com/dreamstalker/rehlds/commit/7891b6196a1fca7c984879e5ad3e9cce9d81f1e3).
Should we add `Q_strcmp` [there](https://github.com/dreamstalker/rehlds/commit/7891b6196a1fca7c984879e5ad3e9cce9d81f1e3#diff-462e3f794ed90c12c86f5d8d5b725c4aL4861) too?