### PR TITLE
Remove link statically with libstdc++

### DIFF
--- a/rehlds/build.gradle
+++ b/rehlds/build.gradle
@@ -167,6 +167,8 @@ void setupToolchain(NativeBinarySpec b) {
 		} else {
 			cfg.compilerOptions.args '-Qoption,cpp,--treat_func_as_string_literal_cpp', '-fno-rtti'
 		}
+
+		cfg.compilerOptions.args '-fno-exceptions'
 		cfg.projectLibpath(project, '/lib/linux32')
 		cfg.extraLibs 'rt', 'dl', 'm', 'steam_api', 'aelf32'
 	}

--- a/rehlds/common/stdc++compat.cpp
+++ b/rehlds/common/stdc++compat.cpp
@@ -1,0 +1,33 @@
+#include <stdio.h>
+
+#if !defined(_WIN32)
+void NORETURN Sys_Error(const char *error, ...);
+
+// This file adds the necessary compatibility tricks to avoid symbols with
+// version GLIBCXX_3.4.16 and bigger, keeping binary compatibility with libstdc++ 4.6.1.
+namespace std
+{
+	// We shouldn't be throwing exceptions at all, but it sadly turns out we call STL (inline) functions that do.
+	void __throw_out_of_range_fmt(const char *fmt, ...)
+	{
+		va_list ap;
+		char buf[1024]; // That should be big enough.
+
+		va_start(ap, fmt);
+		vsnprintf(buf, sizeof(buf), fmt, ap);
+		buf[sizeof(buf) - 1] = '\0';
+		va_end(ap);
+
+		Sys_Error(buf);
+	}
+}; // namespace std
+
+// Technically, this symbol is not in GLIBCXX_3.4.20, but in CXXABI_1.3.8,
+// but that's equivalent, version-wise. Those calls are added by the compiler
+// itself on `new Class[n]` calls.
+extern "C"
+void __cxa_throw_bad_array_new_length()
+{
+	Sys_Error("Bad array new length.");
+}
+#endif // !defined(_WIN32)

--- a/rehlds/rehlds/public_amalgamation.cpp
+++ b/rehlds/rehlds/public_amalgamation.cpp
@@ -1,0 +1,3 @@
+#include "precompiled.h"
+
+#include "stdc++compat.cpp"

--- a/shared_gcc.gradle
+++ b/shared_gcc.gradle
@@ -24,7 +24,7 @@ rootProject.ext.createGccConfig = { boolean release, BinaryKind binKind ->
 						stripSymbolTable: true,
 						staticLibGcc: true,
 						//staticIntel: true,
-						staticLibStdCpp: true,
+						staticLibStdCpp: false,
 				),
 
 				librarianOptions: new GccToolchainConfig.LibrarianOptions(
@@ -49,7 +49,7 @@ rootProject.ext.createGccConfig = { boolean release, BinaryKind binKind ->
 						stripSymbolTable: false,
 						staticLibGcc: true,
 						//staticIntel: true,
-						staticLibStdCpp: true,
+						staticLibStdCpp: false,
 				),
 
 				librarianOptions: new GccToolchainConfig.LibrarianOptions(

--- a/shared_icc.gradle
+++ b/shared_icc.gradle
@@ -24,7 +24,7 @@ rootProject.ext.createIccConfig = { boolean release, BinaryKind binKind ->
 						stripSymbolTable: true,
 						staticLibGcc: true,
 						staticIntel: true,
-						staticLibStdCpp: true,
+						staticLibStdCpp: false,
 				),
 
 				librarianOptions: new GccToolchainConfig.LibrarianOptions(
@@ -49,7 +49,7 @@ rootProject.ext.createIccConfig = { boolean release, BinaryKind binKind ->
 						stripSymbolTable: false,
 						staticLibGcc: true,
 						staticIntel: true,
-						staticLibStdCpp: true,
+						staticLibStdCpp: false,
 				),
 
 				librarianOptions: new GccToolchainConfig.LibrarianOptions(


### PR DESCRIPTION
... and add compatibility tricks to avoid symbols with version GLIBCXX_3.4.16 and bigger.