### PR TITLE
Fix tv_usec calculation in NET_Sleep_Timeout

### DIFF
--- a/rehlds/engine/net_ws.cpp
+++ b/rehlds/engine/net_ws.cpp
@@ -1078,7 +1078,7 @@ DLL_EXPORT int NET_Sleep_Timeout(void)
 
 	struct timeval tv;
 	tv.tv_sec = 0;
-	tv.tv_usec = (1000 / fps) * 1000; // TODO: entirely bad code, fix it completely
+	tv.tv_usec = (1000 * 1000) / fps; // TODO: entirely bad code, fix it completely
 	if (tv.tv_usec <= 0)
 		tv.tv_usec = 1;
 


### PR DESCRIPTION
This is the original code: https://github.com/dreamstalker/rehlds/blob/7326bee095ca1fcc003842f0f6ed5ec622695853/rehlds/engine/net_ws.cpp#L1094
`(1000 / fps) * 1000` and `1000 * 1000 / fps` are not equivalent.