### PR TITLE
Make mapcycle.txt sending optional, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Bugfixed version of rehlds contains an additional cvars:
 <li>sv_rehlds_movecmdrate_avg_punish // Time in minutes for which the player will be banned (0 - Permanent, use a negative number for a kick). Default: 5
 <li>sv_rehlds_movecmdrate_max_burst // Max burst level of 'move' cmds for ban. Default: 2500
 <li>sv_rehlds_movecmdrate_burst_punish // Time in minutes for which the player will be banned (0 - Permanent, use a negative number for a kick). Default: 5
+<li>sv_rehlds_send_mapcycle <1|0> // Send mapcycle.txt in serverinfo message (HLDS behavior, but it is unused on the client). Default: 0
 <li>sv_rehlds_stringcmdrate_max_avg // Max average level of 'string' cmds for ban. Default: 80
 <li>sv_rehlds_stringcmdrate_avg_punish // Time in minutes for which the player will be banned (0 - Permanent, use a negative number for a kick). Default: 5
 <li>sv_rehlds_stringcmdrate_max_burst // Max burst level of 'string' cmds for ban. Default: 400

--- a/msvc/ReHLDS.sln
+++ b/msvc/ReHLDS.sln
@@ -23,6 +23,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "gradle", "gradle", "{FFC337
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dedicated", "..\rehlds\dedicated\msvc\dedicated.vcxproj", "{D49883F3-5C5C-4B9F-B9C7-B31518F228D4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D2516ABB-21F2-4393-8CC9-2BD2D3316CD6}"
+	ProjectSection(SolutionItems) = preProject
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Play|Win32 = Debug Play|Win32

--- a/rehlds/engine/server.h
+++ b/rehlds/engine/server.h
@@ -530,6 +530,7 @@ extern cvar_t sv_rcon_condebug;
 extern cvar_t sv_rehlds_userinfo_transmitted_fields;
 extern cvar_t sv_rehlds_attachedentities_playeranimationspeed_fix;
 extern cvar_t sv_rehlds_local_gametime;
+extern cvar_t sv_rehlds_send_mapcycle;
 #endif
 extern int sv_playermodel;
 


### PR DESCRIPTION
because not used on the client and cause parse error if file is large. Also truncate if sending is enabled.
Added sv_rehlds_send_mapcycle cvar.