### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There are several software requirements for building rehlds:
 </ol>
 
 ### Checking requirements
-####JDK version
+#### JDK version
 Windows<pre>&gt; %JAVA_HOME%\bin\javac -version
 javac 1.8.0_25
 </pre>
@@ -75,15 +75,15 @@ Linux
 javac 1.7.0_65
 </pre>
 
-####Visual Studio
+#### Visual Studio
 Help -> About
 
-####ICC
+#### ICC
 <pre>$ icc --version
 icc (ICC) 15.0.1 20141023
 </pre>
 
-####GCC
+#### GCC
 <pre>$ gcc --version
 gcc (Debian 4.9.2-10) 4.9.2
 </pre>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
