### PR TITLE
Fix IsWhiteSpace

### DIFF
--- a/rehlds/engine/tmessage.cpp
+++ b/rehlds/engine/tmessage.cpp
@@ -142,7 +142,11 @@ int IsEndOfText(char *pText)
 
 int IsWhiteSpace(char space)
 {
+#ifdef REHLDS_FIXES
+	return isspace(space);
+#else
 	return space == ' ' || space == '\t' || space == '\r' || space == '\n';
+#endif	
 }
 
 NOXREF const char *SkipSpace(const char *pText)


### PR DESCRIPTION
By default IsWhiteSpace do not check all whitespace characters.

HLDS behavior:
- ' '	(0x20)	space (SPC)
- '\t'	(0x09)	horizontal tab (TAB)
- '\n'	(0x0a)	newline (LF)
- '\r'	(0x0d)	carriage return (CR)


Added:
- '\f'	(0x0c)	feed (FF)
- '\v'	(0x0b)	vertical tab (VT)

For more info: http://www.cplusplus.com/reference/cctype/isspace/