### PR TITLE
Fix possible null dereferences

### DIFF
--- a/rehlds/engine/net_ws.cpp
+++ b/rehlds/engine/net_ws.cpp
@@ -784,7 +784,11 @@ qboolean NET_LagPacket(qboolean newdata, netsrc_t sock, netadr_t *from, sizebuf_
 	}
 
 	curtime = realtime;
+#ifdef REHLDS_FIXES
+	if (newdata && data)
+#else
 	if (newdata)
+#endif
 	{
 		if (fakeloss.value != 0.0)
 		{

--- a/rehlds/engine/r_studio.cpp
+++ b/rehlds/engine/r_studio.cpp
@@ -458,7 +458,11 @@ void R_StudioCalcBonePosition(int frame, float s, mstudiobone_t *pbone, mstudioa
 				}
 			}
 		}
+#ifdef REHLDS_FIXES
+		if (adj && pbone->bonecontroller[j] != -1)
+#else
 		if (pbone->bonecontroller[j] != -1)
+#endif
 		{
 			pos[j] += adj[pbone->bonecontroller[j]];
 		}

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -4329,6 +4329,7 @@ int SV_CreatePacketEntities_internal(sv_delta_t type, client_t *client, packet_e
 			else
 				newindex = 9999;
 		}
+		
 #ifdef REHLDS_FIXES
 		if (oldnum < oldmax && from)
 #else

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -4329,8 +4329,11 @@ int SV_CreatePacketEntities_internal(sv_delta_t type, client_t *client, packet_e
 			else
 				newindex = 9999;
 		}
-
+#ifdef REHLDS_FIXES
+		if (oldnum < oldmax && from)
+#else
 		if (oldnum < oldmax)
+#endif
 			oldindex = from->entities[oldnum].number;
 		else
 			oldindex = 9999;


### PR DESCRIPTION
Found with cppcheck. They aren't 100% null dereferences, but can create dangerous situations in the future.



Inspect this calls:
1. [R_StudioCalcBonePosition](https://github.com/In-line/rehlds/blob/68fcac46e26f364f32f9220c4156a00f7bf7bbab/rehlds/engine/r_studio.cpp#L1097) `(adj == nullptr)`: 

2. [NET_LagPacket](https://github.com/In-line/rehlds/blob/3fd4e45420dfe754bb3bea4fa49d3f0bb62dbce6/rehlds/engine/net_ws.cpp#L1030) (most of params are null)

And [this line of code](https://github.com/In-line/rehlds/blob/558b1e367f10f1587e2fda401dae06bbf809fa09/rehlds/engine/sv_main.cpp#L4308)

