### PR TITLE
Add WIN32_LEAN_AND_MEAN

### DIFF
--- a/rehlds/HLTV/common/DemoFile.h
+++ b/rehlds/HLTV/common/DemoFile.h
@@ -46,7 +46,6 @@ const int DEMO_PROTOCOL  = 5;
 const int DEMO_STARTUP   = 0;	// this lump contains startup info needed to spawn into the server
 const int DEMO_NORMAL    = 1;	// this lump contains playback info of messages, etc., needed during playback.
 
-#undef PlaySound
 enum class DemoCmd : unsigned char {
 	Unknown = 0,
 	NoRewind,					// startup message

--- a/rehlds/HLTV/common/NetAddress.h
+++ b/rehlds/HLTV/common/NetAddress.h
@@ -31,8 +31,6 @@
 #include "netadr.h"
 #include "BitBuffer.h"
 
-#undef SetPort
-
 class NetAddress {
 public:
 	NetAddress();

--- a/rehlds/common/TextConsoleWin32.h
+++ b/rehlds/common/TextConsoleWin32.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 #include "TextConsole.h"
 

--- a/rehlds/dedicated/src/precompiled.h
+++ b/rehlds/dedicated/src/precompiled.h
@@ -24,6 +24,7 @@
 
 #ifdef _WIN32
 	#include "conproc.h"
+	#include <mmsystem.h> // timeGetTime
 #else
 	#include <signal.h>
 #endif // _WIN32

--- a/rehlds/game_shared/counter.h
+++ b/rehlds/game_shared/counter.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #ifdef _WIN32
+	#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 	#include <windows.h>
 	#include <io.h>
 	#include <direct.h>

--- a/rehlds/public/rehlds/osconfig.h
+++ b/rehlds/public/rehlds/osconfig.h
@@ -48,6 +48,7 @@
 #include <functional>
 
 #ifdef _WIN32 // WINDOWS
+	#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 	#include <windows.h>
 	#include <winsock.h>
 	#include <wsipx.h> // for support IPX

--- a/rehlds/rehlds/jitasm.h
+++ b/rehlds/rehlds/jitasm.h
@@ -74,6 +74,7 @@
 #include <string.h>
 
 #if defined(JITASM_WIN)
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <windows.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
Add WIN32_LEAN_AND_MEAN for prevent tons of unused windows definitions from headers.