### PR TITLE
Fix compilation under linux with ICC 17 (GCC 6.2)

### DIFF
--- a/dep/cppunitlite/src/Assertions.cpp
+++ b/dep/cppunitlite/src/Assertions.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sstream>
+#include <cmath>
 
 void Assertions::StringEquals(std::string message, std::string expected, std::string actual, const char* fileName, long lineNumber) {
 	if (expected != actual) {
@@ -57,7 +58,7 @@ void Assertions::CharEquals(std::string message, char expected, char actual, con
 }
 
 void Assertions::DoubleEquals(std::string message, double expected, double actual, double epsilon, const char* fileName, long lineNumber) {
-	if (abs(expected - actual) > epsilon) {
+	if (std::fabs(expected - actual) > epsilon) {
 		std::stringstream ss;
 		ss << message << " (expected '" << expected << "', got '" << actual << "')";
 		throw TestFailException(ss.str(), std::string(fileName), lineNumber);


### PR DESCRIPTION
gcc version
```
user@user-pc ~/Desktop/programms/rehlds $ gcc --version
gcc (Ubuntu 6.2.0-5ubuntu12) 6.2.0 20161005
```

icc version:
```
user@user-pc ~/Desktop/programms/rehlds $ icc --version
icc (ICC) 17.0.1 20161005
```

```
/home/user/Desktop/programms/rehlds/dep/cppunitlite/src/Assertions.cpp(60): error: more than one instance of overloaded function "abs" matches the argument list:
            function "abs(int)"
            function "std::abs(long long)"
            function "std::abs(long)"
            argument types are: (double)
  	if (abs(expected - actual) > epsilon) {

```