### PR TITLE
Optimize size by removing unused data and functions

### DIFF
--- a/rehlds/build.gradle
+++ b/rehlds/build.gradle
@@ -170,8 +170,11 @@ void setupToolchain(NativeBinarySpec b) {
 		} else {
 			cfg.compilerOptions.args '-Qoption,cpp,--treat_func_as_string_literal_cpp'
 		}
-
+		cfg.compilerOptions.args '-ffunction-sections', '-fdata-sections' // Remove unused code and data
 		cfg.compilerOptions.args '-fno-rtti', '-fno-exceptions'
+
+		cfg.linkerOptions.args '-Wl,--version-script=../version_script.lds', '-Wl,--gc-sections'
+
 		cfg.projectLibpath(project, '/lib/linux32')
 		cfg.extraLibs 'rt', 'dl', 'm', 'steam_api', 'aelf32'
 	}

--- a/version_script.lds
+++ b/version_script.lds
@@ -1,0 +1,8 @@
+HLDS_ABI_1.0 {
+	global: 
+		CreateInterface;
+		F;
+		NET_Sleep_Timeout;
+	local: 
+		*;
+};


### PR DESCRIPTION
I tested this a little bit seems to not break AMX Mod X Hamsandwich module.
This reduced size of engine_i486.so by ~0.6 megabytes. 

Info about `--gc-sections`: https://stackoverflow.com/questions/6687630/how-to-remove-unused-c-c-symbols-with-gcc-and-ld
Info about version script: alliedmodders/amxmodx#447

Credits: @WPMGPRoSToTeMa, @s1lentq 