### PR TITLE
Set stripSymbolTable to false

### DIFF
--- a/shared_gcc.gradle
+++ b/shared_gcc.gradle
@@ -25,7 +25,7 @@ rootProject.ext.createGccConfig = { boolean release, BinaryKind binKind ->
 
 				linkerOptions: new GccToolchainConfig.LinkerOptions(
 						//interProceduralOptimizations: true,
-						stripSymbolTable: true,
+						stripSymbolTable: false,
 						staticLibGcc: false,
 						//staticIntel: true,
 						staticLibStdCpp: false,

--- a/shared_icc.gradle
+++ b/shared_icc.gradle
@@ -25,7 +25,7 @@ rootProject.ext.createIccConfig = { boolean release, BinaryKind binKind ->
 
 				linkerOptions: new GccToolchainConfig.LinkerOptions(
 						interProceduralOptimizations: true,
-						stripSymbolTable: true,
+						stripSymbolTable: false,
 						staticLibGcc: false,
 						staticIntel: true,
 						staticLibStdCpp: false,


### PR DESCRIPTION
After #527 strip removes all function names, which is actually pretty bad for debugging.
Credits: @s1lentq 