### PR TITLE
Add visibility optimizations

### DIFF
--- a/rehlds/build.gradle
+++ b/rehlds/build.gradle
@@ -171,7 +171,7 @@ void setupToolchain(NativeBinarySpec b) {
 			cfg.compilerOptions.args '-Qoption,cpp,--treat_func_as_string_literal_cpp'
 		}
 		cfg.compilerOptions.args '-ffunction-sections', '-fdata-sections' // Remove unused code and data
-		cfg.compilerOptions.args '-fno-rtti', '-fno-exceptions'
+		cfg.compilerOptions.args '-fno-rtti', '-fno-exceptions', '-fvisibility=hidden', '-fvisibility-inlines-hidden'
 
 		cfg.linkerOptions.args '-Wl,--version-script=../version_script.lds', '-Wl,--gc-sections'
 

--- a/rehlds/engine/net_ws.cpp
+++ b/rehlds/engine/net_ws.cpp
@@ -1055,7 +1055,7 @@ qboolean NET_QueuePacket(netsrc_t sock)
 	return NET_GetLong(in_message.data, ret, &in_message.cursize);
 }
 
-DLL_EXPORT int NET_Sleep_Timeout(void)
+EXPORT_FUNCTION int NET_Sleep_Timeout(void)
 {
 	static int32 lasttime;
 	static int numFrames;

--- a/rehlds/engine/sys_dll2.cpp
+++ b/rehlds/engine/sys_dll2.cpp
@@ -88,7 +88,7 @@ NOXREF const char *GetRateRegistrySetting(const char *pchDef)
 	return registry->ReadString("rate", pchDef);
 }
 
-DLL_EXPORT void F(IEngineAPI **api)
+EXPORT_FUNCTION void F(IEngineAPI **api)
 {
 	CreateInterfaceFn fn;
 	fn = Sys_GetFactoryThis();

--- a/rehlds/engine/sys_dll2.h
+++ b/rehlds/engine/sys_dll2.h
@@ -78,7 +78,7 @@ public:
 const char *GetCurrentSteamAppName();
 NOXREF void SetRateRegistrySetting(const char *pchRate);
 NOXREF const char *GetRateRegistrySetting(const char *pchDef);
-DLL_EXPORT void F(IEngineAPI **api);
+EXPORT_FUNCTION void F(IEngineAPI **api);
 void Sys_GetCDKey(char *pszCDKey, int *nLength, int *bDedicated);
 NOXREF void Legacy_ErrorMessage(int nLevel, const char *pszErrorMessage);
 void Legacy_Sys_Printf(char *fmt, ...);


### PR DESCRIPTION
About visibility, copy-paste from: https://gcc.gnu.org/wiki/Visibility

1. It very substantially improves load times of your DSO (Dynamic Shared Object). For example, a huge C++ template-based library which was tested (the TnFOX Boost.Python bindings library) now loads in eight seconds rather than over six minutes! 
2. It lets the optimiser produce better code. PLT indirections (when a function call or variable access must be looked up via the Global Offset Table such as in PIC code) can be completely avoided, thus substantially avoiding pipeline stalls on modern processors and thus much faster code. Furthermore when most of the symbols are bound locally, they can be safely elided (removed) completely through the entire DSO. This gives greater latitude especially to the inliner which no longer needs to keep an entry point around "just in case". 
3. It reduces the size of your DSO by 5-20%. ELF's exported symbol table format is quite a space hog, giving the complete mangled symbol name which with heavy template usage can average around 1000 bytes. C++ templates spew out a huge amount of symbols and a typical C++ library can easily surpass 30,000 symbols which is around 5-6Mb! Therefore if you cut out the 60-80% of unnecessary symbols, your DSO can be megabytes smaller! 
4. Much lower chance of symbol collision. The old woe of two libraries internally using the same symbol for different things is finally behind us with this patch. Hallelujah! **(libstdc++ static linking problems)**