### PR TITLE
Fix (Re)HLDS exploit (Can't use keys or values with a ")

### DIFF
--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -2121,7 +2121,11 @@ int SV_CheckUserInfo(netadr_t *adr, char *userinfo, qboolean bIsReconnecting, in
 	}
 #endif
 
+#ifdef REHLDS_FIXES
+	if (name[0] == 0 || !Q_stricmp(name, "console") || Q_strstr(name, "..") || Q_strstr(name, "\"") || Q_strstr(name, "\\"))
+#else // REHLDS_FIXES
 	if (name[0] == 0 || !Q_stricmp(name, "console") || Q_strstr(name, "..") != NULL)
+#endif // REHLDS_FIXES
 	{
 		Info_SetValueForKey(userinfo, "name", "unnamed", MAX_INFO_STRING);
 	}
@@ -4902,7 +4906,7 @@ void SV_ExtractFromUserinfo(client_t *cl)
 
 	if (newname[0] == '\0' || !Q_stricmp(newname, "console")
 #ifdef REHLDS_FIXES
-		|| Q_strstr(newname, "..") != NULL)
+		|| Q_strstr(newname, "..") || Q_strstr(newname, "\"") || Q_strstr(newname, "\\"))
 #else // REHLDS_FIXES
 		)
 #endif // REHLDS_FIXES


### PR DESCRIPTION
Assume two clients connect with the following string

```connect 48 12345678  \prot\2\unique\-1\raw\261578371d95a424925835ca44f82811   \cl_lw\1\cl_lc\1\*hltv\1\rate\10000\cl_updaterate\20\hspecs\0\hslots\0\hdelay\30\name\test"```

Name will be parsed as ```test"```

Then in ```SV_CheckForDuplicateNames```, ```Info_SetValueForKey``` will fail because of the quotes, and an infinite loop will occur.

I also added a check for ```\```. Altough it's technically impossible to appear, it never hurts to be extra careful with this kind of client input.

TODO (by others, sorry, really busy atm):
- Fix ```COM_Parse``` so that you can't inject quote marks. Other exploits may currently exist that also rely on this bug.