### PR TITLE
Fix family of DoS attacks/exploits [help needed]

### DIFF
--- a/rehlds/engine/net.h
+++ b/rehlds/engine/net.h
@@ -414,3 +414,13 @@ typedef struct netchan_s
 #else // REHLDS_FIXES
 #define Con_NetPrintf Con_Printf
 #endif // REHLDS_FIXES
+
+#ifdef REHLDS_FIXES
+#define NET_SKIP -1
+#define NET_STOP 0
+#define NET_PROCESS 1
+#else // REHLDS_FIXES
+#define NET_SKIP FALSE
+#define NET_STOP FALSE
+#define NET_PROCESS TRUE
+#endif // REHLDS_FIXES

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -3571,8 +3571,14 @@ bool EXT_FUNC NET_GetPacketPreprocessor(uint8* data, unsigned int len, const net
 
 void SV_ReadPackets(void)
 {
-	while (NET_GetPacket(NS_SERVER))
+	int ret;
+	while ((ret = NET_GetPacket(NS_SERVER)) != NET_STOP)
 	{
+#ifdef REHLDS_FIXES
+		if (ret == NET_SKIP)
+			continue;
+#endif // REHLDS_FIXES
+
 		if (SV_FilterPacket())
 		{
 			SV_SendBan();
@@ -7518,8 +7524,14 @@ void SV_CheckForRcon(void)
 	if (g_psv.active || g_pcls.state != ca_dedicated || giActive == DLL_CLOSE || !host_initialized)
 		return;
 
-	while (NET_GetPacket(NS_SERVER))
+	int ret;
+	while ((ret = NET_GetPacket(NS_SERVER)) != NET_STOP)
 	{
+#ifdef REHLDS_FIXES
+		if (ret == NET_SKIP)
+			continue;
+#endif // REHLDS_FIXES
+
 		if (SV_FilterPacket())
 		{
 			SV_SendBan();


### PR DESCRIPTION
This fixes a family of DoS exploits. Old behavior was to stop processing packets altogether when you received something weird. With this commit, it will simply skip the erroneous packets and keep on processing.

This fixes, among other exploits, the following:
```Someone tries to send split packet to the server``` (0xFE exploit)
```Malformed packet number```


Help needed with the following:

- RCON testing needed
- Fakelag is untested and might be broken
- Linux is untested
- Threaded networking is untested
- Should we stop or skip on MAX_UDP_PACKET?


