### PR TITLE
Catch crashes and write minidumps on windows

### DIFF
--- a/rehlds/HLTV/Console/build.gradle
+++ b/rehlds/HLTV/Console/build.gradle
@@ -116,6 +116,7 @@ model {
 						include "ObjectList.cpp"
 						include "TokenLine.cpp"
 						include "textconsole.cpp"
+						include "minidump.cpp"
 						if (GradleCppUtils.windows) {
 							include "TextConsoleWin32.cpp"
 						}

--- a/rehlds/HLTV/Console/msvc/Console.vcxproj
+++ b/rehlds/HLTV/Console/msvc/Console.vcxproj
@@ -19,6 +19,7 @@
     <ClInclude Include="..\..\..\common\ObjectList.h" />
     <ClInclude Include="..\..\..\common\textconsole.h" />
     <ClInclude Include="..\..\..\common\TokenLine.h" />
+    <ClInclude Include="..\..\..\common\minidump.h" />
     <ClInclude Include="..\..\..\engine\mem.h" />
     <ClInclude Include="..\..\..\game_shared\bitvec.h" />
     <ClInclude Include="..\..\..\game_shared\perf_counter.h" />
@@ -59,6 +60,11 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Swds|Win32'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\minidump.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Swds|Win32'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Use</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\engine\mem.cpp" />
     <ClCompile Include="..\..\common\common.cpp">

--- a/rehlds/HLTV/Console/msvc/Console.vcxproj.filters
+++ b/rehlds/HLTV/Console/msvc/Console.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClInclude Include="..\..\..\engine\mem.h">
       <Filter>engine</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\common\minidump.h">
+      <Filter>common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\precompiled.cpp">
@@ -95,6 +98,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\engine\mem.cpp">
       <Filter>engine</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\common\minidump.cpp">
+      <Filter>common</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/rehlds/HLTV/Console/src/System.cpp
+++ b/rehlds/HLTV/Console/src/System.cpp
@@ -1092,8 +1092,15 @@ unsigned char *System::LoadFile(const char *name, int *length)
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
-	gSystem.BuildCommandLine(lpCmdLine);
-	return gSystem.Run();
+#ifdef HLTV_FIXES
+	return CatchAndWriteMiniDump([=]()
+	{
+#endif
+		gSystem.BuildCommandLine(lpCmdLine);
+		return gSystem.Run();
+#ifdef HLTV_FIXES
+	});
+#endif
 }
 
 void System::BuildCommandLine(char *argv)

--- a/rehlds/HLTV/Console/src/System.cpp
+++ b/rehlds/HLTV/Console/src/System.cpp
@@ -1099,7 +1099,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		gSystem.BuildCommandLine(lpCmdLine);
 		return gSystem.Run();
 #ifdef HLTV_FIXES
-	});
+	}, lpCmdLine);
 #endif
 }
 

--- a/rehlds/HLTV/Console/src/precompiled.h
+++ b/rehlds/HLTV/Console/src/precompiled.h
@@ -16,3 +16,7 @@
 // Console stuff
 #include "System.h"
 #include "common/random.h"
+
+#ifdef _WIN32
+#include "minidump.h"
+#endif

--- a/rehlds/HLTV/Console/src/precompiled.h
+++ b/rehlds/HLTV/Console/src/precompiled.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "version/appversion.h"
+
 #include "basetypes.h"
 #include "FileSystem.h"
 #include "strtools.h"

--- a/rehlds/common/minidump.cpp
+++ b/rehlds/common/minidump.cpp
@@ -1,0 +1,138 @@
+#include "precompiled.h"
+
+
+#if defined(HLTV_FIXES) || defined(LAUNCHER_FIXES)
+#ifdef _WIN32
+
+// Gets last error.
+static inline HRESULT GetLastHresult()
+{
+	return HRESULT_FROM_WIN32(GetLastError());
+}
+
+// Creates a new minidump file and dumps the exception info into it.
+static HRESULT WriteMiniDumpUsingExceptionInfo(unsigned int exceptionCode,
+	struct _EXCEPTION_POINTERS *exceptionInfo, MINIDUMP_TYPE minidumpType)
+{
+	// Counter used to make sure minidump names are unique.
+	static int minidumpsWrittenCount{0};
+
+	HMODULE dbghelpModule{LoadLibraryW(L"DbgHelp.dll")};
+	HRESULT errorCode{dbghelpModule ? S_OK : GetLastHresult()};
+
+	using MiniDumpWriteDumpFn = decltype(&MiniDumpWriteDump);
+	MiniDumpWriteDumpFn minidumWriteDump{nullptr};
+	if (SUCCEEDED(errorCode)) 
+	{
+		minidumWriteDump = reinterpret_cast<MiniDumpWriteDumpFn>(GetProcAddress(
+			dbghelpModule, "MiniDumpWriteDump"));
+		errorCode = minidumWriteDump ? S_OK : GetLastHresult();
+	}
+
+	// Creates a unique filename for the minidump based on the current time and
+	// module name.
+	const time_t timeNow{time(nullptr)};
+	tm *localTimeNow{localtime(&timeNow)};
+	if (localTimeNow == nullptr)
+	{
+		errorCode = E_INVALIDARG;
+	}
+
+	// Strip off the rest of the path from the .exe name.
+	wchar_t moduleName[MAX_PATH];
+	if (SUCCEEDED(errorCode))
+	{
+		::SetLastError(NOERROR);
+		::GetModuleFileNameW(nullptr, moduleName, static_cast<DWORD>(ARRAYSIZE(moduleName)));
+
+		errorCode = GetLastHresult();
+	}
+
+	wchar_t fileName[MAX_PATH];
+	HANDLE minidumpFile{nullptr};
+
+	if (SUCCEEDED(errorCode))
+	{
+		wchar_t *strippedModuleName{wcsrchr(moduleName, L'.')};
+		if (strippedModuleName) *strippedModuleName = L'\0';
+
+		strippedModuleName = wcsrchr(moduleName, L'\\');
+		// Move past the last slash.
+		if (strippedModuleName) ++strippedModuleName;
+
+		swprintf(fileName, ARRAYSIZE(fileName), L"%s_crash_%d%.2d%.2d_%.2d%.2d%.2d_%d.mdmp",
+			strippedModuleName ? strippedModuleName : L"unknown",
+			localTimeNow->tm_year + 1900, /* Year less 2000 */
+			localTimeNow->tm_mon + 1,     /* month (0 - 11 : 0 = January) */
+			localTimeNow->tm_mday,        /* day of month (1 - 31) */
+			localTimeNow->tm_hour,        /* hour (0 - 23) */
+			localTimeNow->tm_min,         /* minutes (0 - 59) */
+			localTimeNow->tm_sec,         /* seconds (0 - 59) */
+			++minidumpsWrittenCount);     // ensures the filename is unique
+
+		minidumpFile = CreateFileW(fileName, GENERIC_WRITE, FILE_SHARE_WRITE,
+									nullptr, CREATE_ALWAYS,
+									FILE_ATTRIBUTE_NORMAL, nullptr);
+		errorCode = minidumpFile != INVALID_HANDLE_VALUE ? S_OK : GetLastHresult();
+	}
+
+	if (SUCCEEDED(errorCode) && minidumWriteDump)
+	{
+		// Dump the exception information into the file.
+		MINIDUMP_EXCEPTION_INFORMATION exInfo;
+		exInfo.ThreadId = GetCurrentThreadId();
+		exInfo.ExceptionPointers = exceptionInfo;
+		exInfo.ClientPointers = FALSE;
+
+		const BOOL wasWrittenMinidump{minidumWriteDump(
+			GetCurrentProcess(), GetCurrentProcessId(), minidumpFile,
+			minidumpType, &exInfo, nullptr, nullptr)};
+
+		// If the function succeeds, the return value is TRUE; otherwise, the
+		// return value is FALSE.  To retrieve extended error information, call
+		// GetLastError.  Note that the last error will be an HRESULT value.  If
+		// the operation is canceled, the last error code is HRESULT_FROM_WIN32(ERROR_CANCELLED).
+		// See
+		// https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump
+		errorCode = wasWrittenMinidump ? S_OK : static_cast<HRESULT>(GetLastError());
+	}
+
+	if (minidumpFile && minidumpFile != INVALID_HANDLE_VALUE) 
+	{
+		CloseHandle(minidumpFile);
+	}
+
+	if (dbghelpModule)
+	{
+		FreeLibrary(dbghelpModule);
+	}
+
+	return errorCode;
+}
+
+// Writes process mini dump by exception code and info.
+void WriteMiniDump(unsigned int exceptionCode,
+					struct _EXCEPTION_POINTERS *exceptionInfo)
+{
+	// First try to write it with all the indirectly referenced memory (ie: a
+	// large file).  If that doesn't work, then write a smaller one.
+	auto minidumpType = static_cast<MINIDUMP_TYPE>(
+		MiniDumpWithDataSegs | MiniDumpWithHandleData | MiniDumpWithThreadInfo |
+		MiniDumpWithIndirectlyReferencedMemory);
+
+	if (FAILED(WriteMiniDumpUsingExceptionInfo(exceptionCode, exceptionInfo, minidumpType))) 
+	{
+		minidumpType = MiniDumpWithDataSegs;
+
+		WriteMiniDumpUsingExceptionInfo(exceptionCode, exceptionInfo, minidumpType);
+	}
+}
+
+// Determines either debugger attached to process or not.
+bool HasDebuggerPresent()
+{
+	return ::IsDebuggerPresent() != FALSE;
+}
+
+#endif  // _WIN32
+#endif  // HLTV_FIXES || LAUNCHER_FIXES

--- a/rehlds/common/minidump.h
+++ b/rehlds/common/minidump.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    This program is free software; you can redistribute it and/or modify it
+ *    under the terms of the GNU General Public License as published by the
+ *    Free Software Foundation; either version 2 of the License, or (at
+ *    your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful, but
+ *    WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program; if not, write to the Free Software Foundation,
+ *    Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *    In addition, as a special exception, the author gives permission to
+ *    link the code of this program with the Half-Life Game Engine ("HL
+ *    Engine") and Modified Game Libraries ("MODs") developed by Valve,
+ *    L.L.C ("Valve").  You must obey the GNU General Public License in all
+ *    respects for all of the code used other than the HL Engine and MODs
+ *    from Valve.  If you modify this file, you may extend this exception
+ *    to your version of the file, but you are not obligated to do so.  If
+ *    you do not wish to do so, delete this exception statement from your
+ *    version.
+ *
+ */
+
+#pragma once
+
+#if defined(HLTV_FIXES) || defined(LAUNCHER_FIXES)
+#ifdef _WIN32
+
+#include <DbgHelp.h>
+
+// Writes process mini dump by exception code and info.
+void WriteMiniDump(unsigned int exceptionCode,
+                   struct _EXCEPTION_POINTERS *exceptionInfo);
+
+// Determines either debugger attached to process or not.
+bool HasDebuggerPresent();
+
+// Catches and writes out any exception thrown by the specified function.
+template <typename F>
+int CatchAndWriteMiniDump(F function) 
+{
+	// Don't mask exceptions when running in the debugger.
+	if (HasDebuggerPresent())
+	{
+		return function();
+	}
+
+	__try
+	{
+		return function();
+	} __except (WriteMiniDump(GetExceptionCode(), GetExceptionInformation()),
+				EXCEPTION_EXECUTE_HANDLER) 
+	{
+		// Write the minidump from inside the filter.
+		return GetExceptionCode();
+	}
+}
+
+#endif  // _WIN32
+#endif  // HLTV_FIXES || LAUNCHER_FIXES

--- a/rehlds/common/minidump.h
+++ b/rehlds/common/minidump.h
@@ -55,7 +55,7 @@ int CatchAndWriteMiniDump(F function, const char *commandLine)
 	{
 		return function();
 	} __except (WriteMiniDump(GetExceptionCode(), GetExceptionInformation()),
-				EXCEPTION_EXECUTE_HANDLER) 
+				EXCEPTION_EXECUTE_HANDLER)
 	{
 		// Write the minidump from inside the filter.
 		return GetExceptionCode();

--- a/rehlds/common/minidump.h
+++ b/rehlds/common/minidump.h
@@ -31,8 +31,6 @@
 #if defined(HLTV_FIXES) || defined(LAUNCHER_FIXES)
 #ifdef _WIN32
 
-#include <DbgHelp.h>
-
 // Writes process mini dump by exception code and info.
 void WriteMiniDump(unsigned int exceptionCode,
                    struct _EXCEPTION_POINTERS *exceptionInfo);

--- a/rehlds/common/minidump.h
+++ b/rehlds/common/minidump.h
@@ -37,15 +37,18 @@
 void WriteMiniDump(unsigned int exceptionCode,
                    struct _EXCEPTION_POINTERS *exceptionInfo);
 
-// Determines either debugger attached to process or not.
+// Determines either debugger attached to a process or not.
 bool HasDebuggerPresent();
+
+// Determines either writing mini dumps is enabled or not.  Same as in Source games.
+bool IsWriteMiniDumpsEnabled(const char *commandLine);
 
 // Catches and writes out any exception thrown by the specified function.
 template <typename F>
-int CatchAndWriteMiniDump(F function) 
+int CatchAndWriteMiniDump(F function, const char *commandLine)
 {
-	// Don't mask exceptions when running in the debugger.
-	if (HasDebuggerPresent())
+	// Don't mask exceptions when mini dumps disabled (-nominidumps) or running in the debugger.
+	if (!IsWriteMiniDumpsEnabled(commandLine) || HasDebuggerPresent())
 	{
 		return function();
 	}

--- a/rehlds/dedicated/build.gradle
+++ b/rehlds/dedicated/build.gradle
@@ -24,7 +24,7 @@ void setupToolchain(NativeBinarySpec b) {
 	boolean useGcc = project.hasProperty("useGcc")
 
 	def cfg = rootProject.createToolchainConfig(b);
-	cfg.projectInclude(project, '/src', '/../engine', '/../common', '/../public', '/../public/rehlds');
+	cfg.projectInclude(project, '/src', '/../engine', '/../common', '/../public', '/../public/rehlds', '/../');
 
 	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'DEDICATED', 'LAUNCHER_FIXES', '_CONSOLE'
 

--- a/rehlds/dedicated/build.gradle
+++ b/rehlds/dedicated/build.gradle
@@ -121,6 +121,7 @@ model {
 						include "SteamAppStartUp.cpp"
 						include "textconsole.cpp"
 						include "commandline.cpp"
+						include "minidump.cpp"
 						if (GradleCppUtils.windows) {
 							include "TextConsoleWin32.cpp"
 						}

--- a/rehlds/dedicated/msvc/dedicated.vcxproj
+++ b/rehlds/dedicated/msvc/dedicated.vcxproj
@@ -199,6 +199,7 @@
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\minidump.h" />
     <ClInclude Include="..\..\common\ObjectList.h" />
     <ClInclude Include="..\..\common\SteamAppStartUp.h" />
     <ClInclude Include="..\..\common\textconsole.h" />
@@ -220,6 +221,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\common\commandline.cpp" />
+    <ClCompile Include="..\..\common\minidump.cpp" />
     <ClCompile Include="..\..\common\ObjectList.cpp" />
     <ClCompile Include="..\..\common\SteamAppStartUp.cpp" />
     <ClCompile Include="..\..\common\textconsole.cpp" />

--- a/rehlds/dedicated/msvc/dedicated.vcxproj.filters
+++ b/rehlds/dedicated/msvc/dedicated.vcxproj.filters
@@ -47,6 +47,9 @@
     <ClInclude Include="..\..\common\SteamAppStartUp.h">
       <Filter>common</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\minidump.h">
+      <Filter>common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\sys_ded.cpp">
@@ -93,6 +96,9 @@
     </ClCompile>
     <ClCompile Include="..\..\common\commandline.cpp">
       <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\minidump.cpp">
+      <Filter>common</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/rehlds/dedicated/src/precompiled.h
+++ b/rehlds/dedicated/src/precompiled.h
@@ -23,6 +23,7 @@
 
 #ifdef _WIN32
 	#include "conproc.h"
+	#include "minidump.h"
 	#include <mmsystem.h> // timeGetTime
 #else
 	#include <signal.h>

--- a/rehlds/dedicated/src/precompiled.h
+++ b/rehlds/dedicated/src/precompiled.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "version/appversion.h"
+
 #include "basetypes.h"
 #include "FileSystem.h"
 #include "strtools.h"

--- a/rehlds/dedicated/src/sys_window.cpp
+++ b/rehlds/dedicated/src/sys_window.cpp
@@ -239,11 +239,18 @@ void Sys_WriteProcessIdFile()
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
-	if (ShouldLaunchAppViaSteam(lpCmdLine, STDIO_FILESYSTEM_LIB, STDIO_FILESYSTEM_LIB))
-		return 0;
+#ifdef LAUNCHER_FIXES
+	return CatchAndWriteMiniDump([=]()
+	{
+#endif
+		if (ShouldLaunchAppViaSteam(lpCmdLine, STDIO_FILESYSTEM_LIB, STDIO_FILESYSTEM_LIB))
+			return 0;
 
-	//auto command = CommandLineToArgvW(GetCommandLineW(), (int *)&lpCmdLine);
-	auto ret = StartServer(lpCmdLine);
-	//LocalFree(command);
-	return ret;
+		//auto command = CommandLineToArgvW(GetCommandLineW(), (int *)&lpCmdLine);
+		auto ret = StartServer(lpCmdLine);
+		//LocalFree(command);
+		return ret;
+#ifdef LAUNCHER_FIXES
+	});
+#endif
 }

--- a/rehlds/dedicated/src/sys_window.cpp
+++ b/rehlds/dedicated/src/sys_window.cpp
@@ -251,6 +251,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		//LocalFree(command);
 		return ret;
 #ifdef LAUNCHER_FIXES
-	});
+	}, lpCmdLine);
 #endif
 }


### PR DESCRIPTION
Kinda hard to debug issues without crash dumps on hands.  Add crash dumps writing support on Windows. Makes resolving issues like https://github.com/dreamstalker/rehlds/issues/523, https://github.com/dreamstalker/rehlds/issues/698, https://github.com/dreamstalker/rehlds/issues/699 easier.

Crash dump is written to file in the same directory as crashed executable.  Crash dump file name format: `<exe name>_<app version>_crash_<date YYYYMMDD>_<time HHMMSS>_<unique counter>.mdmp`
for example, `hlds_3.6.0.675-dev+m_crash_20190702_005019_1.mdmp`

Command line option `-nominidumps` disables mini dump writing facility (same behavior as in Source games). Also, mini dumps are not written when debugger is attached.

Uses `DbgHelp.dll` to write minidumps, should be present on all Windows versions, but **REQUIRES checking** on Windows XP+. Tested on Windows 10 18362.

Tries to write minidump with data segments, handles, threads and indirectly referenced memory first.
As a fallback, writes minidump with data segments only.
