### PR TITLE
Small update sv_use_entity_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Bugfixed version of rehlds contains an additional cvars:
 <li>sv_rehlds_maxclients_from_single_ip // Limit number of connections from the single ip address. Default: 5
 <li>sv_use_entity_file // Use custom entity file for a map. Path to an entity file will be "maps/[map name].ent". 0 - use original entities. 1 - use .ent files from maps directory. 2 - use .ent files from maps directory and create new .ent file if not exist.
 </ul>
+	
 ## Commands
 Bugfixed version of rehlds contains an additional commands:
 <ul>

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ Bugfixed version of rehlds contains an additional cvars:
 <li>sv_rehlds_userinfo_transmitted_fields // Userinfo fields only with these keys will be transmitted to clients via network. If not set then all fields will be transmitted (except prefixed with underscore). Each key must be prefixed by backslash, for example "\name\model\*sid\*hltv\bottomcolor\topcolor". See [wiki](https://github.com/dreamstalker/rehlds/wiki/Userinfo-keys) to collect sufficient set of keys for your server. Default: ""
 <li>sv_rehlds_attachedentities_playeranimationspeed_fix // Fixes bug with gait animation speed increase when player has some attached entities (aiments). Can cause animation lags when cl_updaterate is low. Default: 0
 <li>sv_rehlds_maxclients_from_single_ip // Limit number of connections from the single ip address. Default: 5
-<li>sv_use_entity_file // Use custom entity file for a map. Path to an entity file will be "maps/[map name].ent". Default: 0
+<li>sv_use_entity_file // Use custom entity file for a map. Path to an entity file will be "maps/[map name].ent". 0 - use original entities. 1 - use .ent files from maps directory. 2 - use .ent files from maps directory and create new .ent file if not exist.
 </ul>
-
 ## Commands
 Bugfixed version of rehlds contains an additional commands:
 <ul>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Bugfixed version of rehlds contains an additional cvars:
 <li>sv_rehlds_maxclients_from_single_ip // Limit number of connections from the single ip address. Default: 5
 <li>sv_use_entity_file // Use custom entity file for a map. Path to an entity file will be "maps/[map name].ent". 0 - use original entities. 1 - use .ent files from maps directory. 2 - use .ent files from maps directory and create new .ent file if not exist.
 </ul>
-	
+
 ## Commands
 Bugfixed version of rehlds contains an additional commands:
 <ul>

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -6152,11 +6152,14 @@ void SV_LoadEntities(void)
 
 		if (!FS_FileExists(name))
 		{
-			FILE *f = FS_Open(name, "wb");
-			if (f)
+			if (sv_use_entity_file.value > 1.0f)
 			{
-				FS_Write(g_psv.worldmodel->entities, Q_strlen(g_psv.worldmodel->entities), 1, f);
-				FS_Close(f);
+				FILE *f = FS_Open(name, "wb");
+				if (f)
+				{
+					FS_Write(g_psv.worldmodel->entities, Q_strlen(g_psv.worldmodel->entities), 1, f);
+					FS_Close(f);
+				}
 			}
 		}
 		else


### PR DESCRIPTION
Now if sv_use_entity_file set to 1, don't create new .ent files, use only exist.