### PR TITLE
Cbuf_Execute: Add checks commented out for multi-lines.

### DIFF
--- a/rehlds/engine/cmd.cpp
+++ b/rehlds/engine/cmd.cpp
@@ -164,8 +164,9 @@ void Cbuf_Execute(void)
 {
 	int i;
 	char *text;
-	char line[MAX_CMD_LINE];
+	char line[MAX_CMD_LINE] = {0};
 	int quotes;
+	bool commented;
 
 	while (cmd_text.cursize)
 	{
@@ -173,12 +174,21 @@ void Cbuf_Execute(void)
 		text = (char *)cmd_text.data;
 
 		quotes = 0;
+		commented = false;
+
+#ifdef REHLDS_FIXES
+		if (cmd_text.cursize > 1 && text[0] == '/' && text[1] == '/')
+			commented = true;
+#endif
+
 		for (i = 0; i < cmd_text.cursize; i++)
 		{
 			if (text[i] == '"')
 				quotes++;
-			if (!(quotes & 1) && text[i] == ';')
-				break;	// don't break if inside a quoted string
+
+			if (!(quotes & 1) && !commented && text[i] == ';')
+				break;	// don't break if inside a quoted or commented out strings
+
 			if (text[i] == '\n')
 				break;
 		}


### PR DESCRIPTION
## Description

Cbuf_Execute doesn't ignore commented out string in case when string contains separator character `;` inside commented out string.

## Steps to reproduce

1. Config file `test.cfg` contains 
>// ; echo "test: commented out string"
2. Execute `exec test.cfg`
3. The text will printed in the console.