### PR TITLE
Fix _vsnprintf on windows

### DIFF
--- a/rehlds/public/tier0/dbg.h
+++ b/rehlds/public/tier0/dbg.h
@@ -422,7 +422,7 @@ public:
 		va_list arg_ptr;
 
 		va_start(arg_ptr, pszFormat);
-#ifdef _WIN32
+#ifdef _WIN32 && !defined(_CRT_SECURE_NO_WARNINGS)
 		_vsnprintf_s(m_szBuf, sizeof(m_szBuf) - 1, sizeof(m_szBuf) - 1, pszFormat, arg_ptr);
 #else
 		_vsnprintf(m_szBuf, sizeof(m_szBuf) - 1, pszFormat, arg_ptr);

--- a/rehlds/public/tier0/dbg.h
+++ b/rehlds/public/tier0/dbg.h
@@ -422,7 +422,7 @@ public:
 		va_list arg_ptr;
 
 		va_start(arg_ptr, pszFormat);
-#ifdef _WIN32 && !defined(_CRT_SECURE_NO_WARNINGS)
+#if defined(_WIN32) && !defined(_CRT_SECURE_NO_WARNINGS)
 		_vsnprintf_s(m_szBuf, sizeof(m_szBuf) - 1, sizeof(m_szBuf) - 1, pszFormat, arg_ptr);
 #else
 		_vsnprintf(m_szBuf, sizeof(m_szBuf) - 1, pszFormat, arg_ptr);

--- a/rehlds/public/tier0/dbg.h
+++ b/rehlds/public/tier0/dbg.h
@@ -422,7 +422,11 @@ public:
 		va_list arg_ptr;
 
 		va_start(arg_ptr, pszFormat);
+#ifdef _WIN32
+		_vsnprintf_s(m_szBuf, sizeof(m_szBuf) - 1, sizeof(m_szBuf) - 1, pszFormat, arg_ptr);
+#else
 		_vsnprintf(m_szBuf, sizeof(m_szBuf) - 1, pszFormat, arg_ptr);
+#endif
 		va_end(arg_ptr);
 
 		m_szBuf[sizeof(m_szBuf) - 1] = 0;


### PR DESCRIPTION
warning C4996: _vsnprintf': This function or variable may be unsafe. Consider using _vsnprintf_s instead.