### PR TITLE
Change launcher sybsystem to CONSOLE

### DIFF
--- a/rehlds/common/TextConsoleWin32.cpp
+++ b/rehlds/common/TextConsoleWin32.cpp
@@ -81,6 +81,9 @@ CTextConsoleWin32::~CTextConsoleWin32()
 
 bool CTextConsoleWin32::Init(IBaseSystem *system)
 {
+#ifdef LAUNCHER_FIXES
+	if(!AttachConsole(ATTACH_PARENT_PROCESS))
+#endif
 	if (!AllocConsole())
 		m_System = system;
 

--- a/rehlds/dedicated/build.gradle
+++ b/rehlds/dedicated/build.gradle
@@ -37,7 +37,7 @@ void setupToolchain(NativeBinarySpec b) {
 
 		cfg.singleDefines('_CRT_SECURE_NO_WARNINGS');
 
-		cfg.linkerOptions.args('/SUBSYSTEM:WINDOWS,5.01');
+		cfg.linkerOptions.args('/SUBSYSTEM:CONSOLE,5.01');
 		cfg.compilerOptions.args '/Ob2', '/Oi', '/GF', '/GR-';
 		cfg.extraLibs "ws2_32.lib", "winmm.lib", "user32.lib", "advapi32.lib", "shell32.lib"
 	}

--- a/rehlds/dedicated/msvc/dedicated.vcxproj
+++ b/rehlds/dedicated/msvc/dedicated.vcxproj
@@ -87,7 +87,7 @@
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>ws2_32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/rehlds/dedicated/src/sys_window.cpp
+++ b/rehlds/dedicated/src/sys_window.cpp
@@ -237,12 +237,15 @@ void Sys_WriteProcessIdFile()
 	;
 }
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
+//int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
+int main(int argc, char *argv[])
 {
+	auto lpCmdLine = GetCommandLine();
 #ifdef LAUNCHER_FIXES
 	return CatchAndWriteMiniDump([=]()
 	{
 #endif
+		
 		if (ShouldLaunchAppViaSteam(lpCmdLine, STDIO_FILESYSTEM_LIB, STDIO_FILESYSTEM_LIB))
 			return 0;
 


### PR DESCRIPTION
As long as there's no VGUI, better to use console subsystem for better compability with windows command line and third party applications
Attaching to parent window: when you open hlds from command line(cmd.exe or powershell), HLDS will use window of this command line instead of creating new one. It gives possibility to use stdin/stdout without issues.