### PR TITLE
Add GetEntityInit hook

### DIFF
--- a/rehlds/engine/sys_dll.cpp
+++ b/rehlds/engine/sys_dll.cpp
@@ -770,9 +770,19 @@ const char* EXT_FUNC NameForFunction(uint32 function)
 	return NULL;
 }
 
-ENTITYINIT EXT_FUNC GetEntityInit(char *pClassName)
+ENTITYINIT GetEntityInit_internal(char *pClassName)
 {
 	return (ENTITYINIT)GetDispatch(pClassName);
+}
+
+ENTITYINIT EXT_FUNC GetEntityInit_api(char *pClassName)
+{
+	return g_RehldsHookchains.m_GetEntityInit.callChain(GetEntityInit_internal, pClassName);
+}
+
+ENTITYINIT GetEntityInit(char *pClassName)
+{
+	return GetEntityInit_api(pClassName);
 }
 
 FIELDIOFUNCTION GetIOFunction(char *pName)

--- a/rehlds/engine/sys_dll.h
+++ b/rehlds/engine/sys_dll.h
@@ -120,6 +120,8 @@ uint32 FindNameInTable(extensiondll_t *pDll, const char *pName);
 NOBODY const char *ConvertNameToLocalPlatform(const char *pchInName);
 uint32 FunctionFromName(const char *pName);
 const char *NameForFunction(uint32 function);
+ENTITYINIT GetEntityInit_internal(char *pClassName);
+ENTITYINIT GetEntityInit_api(char *pClassName);
 ENTITYINIT GetEntityInit(char *pClassName);
 FIELDIOFUNCTION GetIOFunction(char *pName);
 NOBODY void DLL_SetModKey(modinfo_t *pinfo, char *pkey, char *pvalue);

--- a/rehlds/public/rehlds/rehlds_api.h
+++ b/rehlds/public/rehlds/rehlds_api.h
@@ -37,7 +37,7 @@
 #include "pr_dlls.h"
 
 #define REHLDS_API_VERSION_MAJOR 3
-#define REHLDS_API_VERSION_MINOR 8
+#define REHLDS_API_VERSION_MINOR 9
 
 //Steam_NotifyClientConnect hook
 typedef IHookChain<qboolean, IGameClient*, const void*, unsigned int> IRehldsHook_Steam_NotifyClientConnect;
@@ -207,6 +207,11 @@ typedef IVoidHookChainRegistry<> IRehldsHookRegistry_SV_Frame;
 typedef IHookChain<bool, IGameClient *, bool> IRehldsHook_SV_ShouldSendConsistencyList;
 typedef IHookChainRegistry<bool, IGameClient *, bool> IRehldsHookRegistry_SV_ShouldSendConsistencyList;
 
+//GetEntityInit hook
+typedef IHookChain<ENTITYINIT, char *> IRehldsHook_GetEntityInit;
+typedef IHookChainRegistry<ENTITYINIT, char *> IRehldsHookRegistry_GetEntityInit;
+
+
 class IRehldsHookchains {
 public:
 	virtual ~IRehldsHookchains() { }
@@ -253,6 +258,7 @@ public:
 	virtual IRehldsHookRegistry_SV_CheckConnectionLessRateLimits* SV_CheckConnectionLessRateLimits() = 0;
 	virtual IRehldsHookRegistry_SV_Frame* SV_Frame() = 0;
 	virtual IRehldsHookRegistry_SV_ShouldSendConsistencyList* SV_ShouldSendConsistencyList() = 0;
+	virtual IRehldsHookRegistry_GetEntityInit* GetEntityInit() = 0;
 };
 
 struct RehldsFuncs_t {

--- a/rehlds/rehlds/rehlds_api_impl.cpp
+++ b/rehlds/rehlds/rehlds_api_impl.cpp
@@ -515,7 +515,7 @@ RehldsFuncs_t g_RehldsApiFuncs =
 	&AddCvarListener_api,
 	&RemoveExtDll_api,
 	&RemoveCvarListener_api,
-	&GetEntityInit,
+	&GetEntityInit_api,
 	&MSG_ReadChar_api,
 	&MSG_ReadByte_api,
 	&MSG_ReadLong_api,
@@ -829,6 +829,10 @@ IRehldsHookRegistry_SV_Frame* CRehldsHookchains::SV_Frame() {
 
 IRehldsHookRegistry_SV_ShouldSendConsistencyList* CRehldsHookchains::SV_ShouldSendConsistencyList() {
 	return &m_SV_ShouldSendConsistencyList;
+}
+
+IRehldsHookRegistry_GetEntityInit* CRehldsHookchains::GetEntityInit() {
+	return &m_GetEntityInit;
 }
 
 int EXT_FUNC CRehldsApi::GetMajorVersion()

--- a/rehlds/rehlds/rehlds_api_impl.h
+++ b/rehlds/rehlds/rehlds_api_impl.h
@@ -202,6 +202,10 @@ typedef IVoidHookChainRegistryImpl<> CRehldsHookRegistry_SV_Frame;
 typedef IHookChainImpl<bool, IGameClient *, bool> CRehldsHook_SV_ShouldSendConsistencyList;
 typedef IHookChainRegistryImpl<bool, IGameClient *, bool> CRehldsHookRegistry_SV_ShouldSendConsistencyList;
 
+//GetEntityInit hook
+typedef IHookChainImpl<ENTITYINIT, char *> CRehldsHook_GetEntityInit;
+typedef IHookChainRegistryImpl<ENTITYINIT, char *> CRehldsHookRegistry_GetEntityInit;
+
 class CRehldsHookchains : public IRehldsHookchains {
 public:
 	CRehldsHookRegistry_Steam_NotifyClientConnect m_Steam_NotifyClientConnect;
@@ -246,6 +250,7 @@ public:
 	CRehldsHookRegistry_SV_CheckConnectionLessRateLimits m_SV_CheckConnectionLessRateLimits;
 	CRehldsHookRegistry_SV_Frame m_SV_Frame;
 	CRehldsHookRegistry_SV_ShouldSendConsistencyList m_SV_ShouldSendConsistencyList;
+	CRehldsHookRegistry_GetEntityInit m_GetEntityInit;
 
 public:
 	EXT_FUNC virtual IRehldsHookRegistry_Steam_NotifyClientConnect* Steam_NotifyClientConnect();
@@ -290,6 +295,7 @@ public:
 	EXT_FUNC virtual IRehldsHookRegistry_SV_CheckConnectionLessRateLimits* SV_CheckConnectionLessRateLimits();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_Frame* SV_Frame();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_ShouldSendConsistencyList* SV_ShouldSendConsistencyList();
+	EXT_FUNC virtual IRehldsHookRegistry_GetEntityInit* GetEntityInit();
 };
 
 extern CRehldsHookchains g_RehldsHookchains;

--- a/rehlds/version/version.h
+++ b/rehlds/version/version.h
@@ -6,5 +6,5 @@
 #pragma once
 
 #define VERSION_MAJOR		3
-#define VERSION_MINOR		8
+#define VERSION_MINOR		9
 #define VERSION_MAINTENANCE	0


### PR DESCRIPTION
I got the request to add the hookchain for `GetEntityInit`, so this PR just adds it, nothing more, nothing less. 😛 

Fixes #722.

Signed-off-by: Karol Szuster <karolsz9898@gmail.com>