### PR TITLE
Add new CVar `sv_usercmd_custom_random_seed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 <li>sv_rehlds_attachedentities_playeranimationspeed_fix // Fixes bug with gait animation speed increase when player has some attached entities (aiments). Can cause animation lags when cl_updaterate is low. Default: 0
 <li>sv_rehlds_maxclients_from_single_ip // Limit number of connections from the single ip address. Default: 5
 <li>sv_use_entity_file // Use custom entity file for a map. Path to an entity file will be "maps/[map name].ent". 0 - use original entities. 1 - use .ent files from maps directory. 2 - use .ent files from maps directory and create new .ent file if not exist.
+<li>sv_usercmd_custom_random_seed // When enabled server will populate an additional random seed independent of the client. Default: 0
 </ul>
 </details>
 

--- a/rehlds/engine/server.h
+++ b/rehlds/engine/server.h
@@ -376,6 +376,7 @@ extern cvar_t sv_rehlds_userinfo_transmitted_fields;
 extern cvar_t sv_rehlds_attachedentities_playeranimationspeed_fix;
 extern cvar_t sv_rehlds_local_gametime;
 extern cvar_t sv_rehlds_send_mapcycle;
+extern cvar_t sv_usercmd_custom_random_seed;
 #endif
 extern int sv_playermodel;
 

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -209,6 +209,7 @@ cvar_t sv_rehlds_local_gametime = {"sv_rehlds_local_gametime", "0", 0, 0.0f, nul
 cvar_t sv_rehlds_send_mapcycle = { "sv_rehlds_send_mapcycle", "0", 0, 0.0f, nullptr };
 cvar_t sv_rehlds_maxclients_from_single_ip = { "sv_rehlds_maxclients_from_single_ip", "5", 0, 5.0f, nullptr };
 cvar_t sv_use_entity_file = { "sv_use_entity_file", "0", 0, 0.0f, nullptr };
+cvar_t sv_usercmd_custom_random_seed = { "sv_usercmd_custom_random_seed", "0", 0, 0.0f, nullptr };
 #endif
 
 delta_t *SV_LookupDelta(char *name)
@@ -8016,6 +8017,7 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_rollspeed);
 	Cvar_RegisterVariable(&sv_rollangle);
 	Cvar_RegisterVariable(&sv_use_entity_file);
+	Cvar_RegisterVariable(&sv_usercmd_custom_random_seed);
 #endif
 
 	for (int i = 0; i < MAX_MODELS; i++)

--- a/rehlds/engine/sv_user.cpp
+++ b/rehlds/engine/sv_user.cpp
@@ -773,6 +773,14 @@ void SV_RunCmd(usercmd_t *ucmd, int random_seed)
 	if (!host_client->fakeclient)
 		SV_SetupMove(host_client);
 
+#ifdef REHLDS_FIXES
+	if (sv_usercmd_custom_random_seed.value)
+	{
+		float fltTimeNow = float(Sys_FloatTime() * 1000.0);
+		random_seed = *reinterpret_cast<int *>((char *)&fltTimeNow);
+	}
+#endif
+
 	gEntityInterface.pfnCmdStart(sv_player, ucmd, random_seed);
 	frametime = float(ucmd->msec * 0.001);
 	host_client->svtimebase = frametime + host_client->svtimebase;


### PR DESCRIPTION

| CVar | Def. value | Description | 
|:--|:--:|:--|
| sv_usercmd_custom_random_seed | 0 | When enabled server will populate an additional random seed independent of the client. | 

Ported from [CS:GO leaked source code](https://github.com/perilouswithadollarsign/cstrike15_src/blob/f82112a2388b841d72cb62ca48ab1846dfcc11c8/game/server/player.cpp#L3719)

Thanks to `danil.nesvetaev` for the reminder of this functionality in CS:GO. 👍