### PR TITLE
Netchan_FlushIncoming: Don't clear global buffer of incoming network messages

### DIFF
--- a/rehlds/engine/net_chan.cpp
+++ b/rehlds/engine/net_chan.cpp
@@ -1389,10 +1389,13 @@ void Netchan_FlushIncoming(netchan_t *chan, int stream)
 {
 	fragbuf_t *p, *n;
 
-#ifndef REHLDS_FIXES
-	SZ_Clear(&net_message);
-	msg_readcount = 0;
+#ifdef REHLDS_FIXES
+	if (chan->player_slot == host_client - g_psvs.clients)
 #endif
+	{
+		SZ_Clear(&net_message);
+		msg_readcount = 0;
+	}
 
 	p = chan->incomingbufs[stream];
 	while (p)

--- a/rehlds/engine/net_chan.cpp
+++ b/rehlds/engine/net_chan.cpp
@@ -1389,8 +1389,10 @@ void Netchan_FlushIncoming(netchan_t *chan, int stream)
 {
 	fragbuf_t *p, *n;
 
+#ifndef REHLDS_FIXES
 	SZ_Clear(&net_message);
 	msg_readcount = 0;
+#endif
 
 	p = chan->incomingbufs[stream];
 	while (p)

--- a/rehlds/engine/net_chan.cpp
+++ b/rehlds/engine/net_chan.cpp
@@ -1390,7 +1390,7 @@ void Netchan_FlushIncoming(netchan_t *chan, int stream)
 	fragbuf_t *p, *n;
 
 #ifdef REHLDS_FIXES
-	if (chan->player_slot == host_client - g_psvs.clients)
+	if ((chan->player_slot - 1) == host_client - g_psvs.clients)
 #endif
 	{
 		SZ_Clear(&net_message);


### PR DESCRIPTION
Issue related to #888 is that, what we can't call SV_DropClient for another client inside callback while handling incoming network messages,
because call chains are `SV_DropClient -> Netchan_Clear -> Netchan_ClearFragments -> Netchan_FlushIncoming -> msg_readcount` cause clearing `msg_readcount` and `net_message` for all.

```
- SV_ConnectClient PRE  (id 1) net_message[msg_readcount] - there is something to read here
- SV_ConnectClient 3rd party   call SV_DropClient (id 2) -> msg_readcount = 0
- SV_ConnectClient POST (id 1) net_message[msg_readcount] - we have nothing left to read for this client, steam ticket is empty
```

Every incoming message initializes these global variables, so do we really need to clean them up while flushing?