### PR TITLE
Add SV_AllowPhysent hook

### DIFF
--- a/rehlds/engine/sv_user.cpp
+++ b/rehlds/engine/sv_user.cpp
@@ -511,6 +511,14 @@ void SV_CopyEdictToPhysent(physent_t *pe, int e, edict_t *check)
 	pe->vuser4[2] = check->v.vuser4[2];
 }
 
+bool EXT_FUNC SV_AllowPhysent_mod(edict_t* check, edict_t* sv_player) {
+	return true;
+}
+
+bool SV_AllowPhysent(edict_t* check, edict_t* sv_player) {
+	return g_RehldsHookchains.m_SV_AllowPhysent.callChain(SV_AllowPhysent_mod, check, sv_player);
+}
+
 void SV_AddLinksToPM_(areanode_t *node, float *pmove_mins, float *pmove_maxs)
 {
 	struct link_s *l;
@@ -546,6 +554,11 @@ void SV_AddLinksToPM_(areanode_t *node, float *pmove_mins, float *pmove_maxs)
 
 		if (check->v.solid != SOLID_BSP && check->v.solid != SOLID_BBOX && check->v.solid != SOLID_SLIDEBOX && check->v.solid != SOLID_NOT)
 			continue;
+
+		// Apply our own custom checks
+		if (!SV_AllowPhysent(check, sv_player)) {
+			continue;
+		}
 
 		e = NUM_FOR_EDICT(check);
 		ve = &pmove->visents[pmove->numvisent];

--- a/rehlds/public/rehlds/rehlds_api.h
+++ b/rehlds/public/rehlds/rehlds_api.h
@@ -255,6 +255,10 @@ typedef IVoidHookChainRegistry<resourcetype_t, const char *, int, unsigned char,
 typedef IVoidHookChain<const char *> IRehldsHook_SV_ClientPrintf;
 typedef IVoidHookChainRegistry<const char *> IRehldsHookRegistry_SV_ClientPrintf;
 
+//SV_AllowPhysent hook
+typedef IHookChain<bool, edict_t*, edict_t*> IRehldsHook_SV_AllowPhysent;
+typedef IHookChainRegistry<bool, edict_t*, edict_t*> IRehldsHookRegistry_SV_AllowPhysent;
+
 class IRehldsHookchains {
 public:
 	virtual ~IRehldsHookchains() { }
@@ -313,6 +317,7 @@ public:
 	virtual IRehldsHookRegistry_EV_Precache* EV_Precache() = 0;
 	virtual IRehldsHookRegistry_SV_AddResource* SV_AddResource() = 0;
 	virtual IRehldsHookRegistry_SV_ClientPrintf* SV_ClientPrintf() = 0;
+	virtual IRehldsHookRegistry_SV_AllowPhysent* SV_AllowPhysent() = 0;
 };
 
 struct RehldsFuncs_t {

--- a/rehlds/rehlds/rehlds_api_impl.cpp
+++ b/rehlds/rehlds/rehlds_api_impl.cpp
@@ -879,6 +879,10 @@ IRehldsHookRegistry_SV_ClientPrintf* CRehldsHookchains::SV_ClientPrintf(){
 	return &m_SV_ClientPrintf;
 }
 
+IRehldsHookRegistry_SV_AllowPhysent* CRehldsHookchains::SV_AllowPhysent() {
+	return &m_SV_AllowPhysent;
+}
+
 int EXT_FUNC CRehldsApi::GetMajorVersion()
 {
 	return REHLDS_API_VERSION_MAJOR;

--- a/rehlds/rehlds/rehlds_api_impl.h
+++ b/rehlds/rehlds/rehlds_api_impl.h
@@ -250,6 +250,10 @@ typedef IVoidHookChainRegistryImpl<resourcetype_t, const char*, int, unsigned ch
 typedef IVoidHookChainImpl<const char*> CRehldsHook_SV_ClientPrintf;
 typedef IVoidHookChainRegistryImpl<const char*> CRehldsHookRegistry_SV_ClientPrintf;
 
+//SV_AllowPhysent hook
+typedef IHookChainImpl<bool, edict_t*, edict_t*> CRehldsHook_SV_AllowPhysent;
+typedef IHookChainRegistryImpl<bool, edict_t*, edict_t*> CRehldsHookRegistry_SV_AllowPhysent;
+
 class CRehldsHookchains : public IRehldsHookchains {
 public:
 	CRehldsHookRegistry_Steam_NotifyClientConnect m_Steam_NotifyClientConnect;
@@ -306,6 +310,7 @@ public:
 	CRehldsHookRegistry_EV_Precache m_EV_Precache;
 	CRehldsHookRegistry_SV_AddResource m_SV_AddResource;
 	CRehldsHookRegistry_SV_ClientPrintf m_SV_ClientPrintf;
+	CRehldsHookRegistry_SV_AllowPhysent m_SV_AllowPhysent;
 
 public:
 	EXT_FUNC virtual IRehldsHookRegistry_Steam_NotifyClientConnect* Steam_NotifyClientConnect();
@@ -362,6 +367,7 @@ public:
 	EXT_FUNC virtual IRehldsHookRegistry_EV_Precache* EV_Precache();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_AddResource* SV_AddResource();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_ClientPrintf* SV_ClientPrintf();
+	EXT_FUNC virtual IRehldsHookRegistry_SV_AllowPhysent* SV_AllowPhysent();
 };
 
 extern CRehldsHookchains g_RehldsHookchains;


### PR DESCRIPTION
Can be used to create a custom semiclip without needing a module

Ex:

`#include <amxmodx>
#include <cstrike>
#include <fakemeta>
#include <reapi>

public plugin_init() {
    register_plugin("Semiclip", "0.0.1", "JustGo")
    
    register_forward(FM_AddToFullPack,"fw_AddToFullPack_Post",1)

    RegisterHookChain(RH_SV_AllowPhysent, "SV_AllowPhysent")
}

public SV_AllowPhysent(ent, sv_player) {
    if(!is_user_alive(ent) || !is_user_alive(sv_player)) return HC_CONTINUE

    if(!isSameTeam(ent, sv_player)) return HC_CONTINUE

    SetHookChainReturn(ATYPE_BOOL, false)
    return HC_SUPERCEDE
}

public fw_AddToFullPack_Post(es_handle,e,ent,host,hostflags,player,pSet)
{
    if(!is_user_alive(host) || !is_user_alive(ent)) return FMRES_IGNORED

    if(isSameTeam(host, ent))
    {
        set_es(es_handle, ES_Solid, SOLID_NOT);
    }
    return FMRES_HANDLED;
}

stock isSameTeam(id1, id2) {
    return (cs_get_user_team(id1) == cs_get_user_team(id2))
}
`