### PR TITLE
Add SV_ClipToLinks_Point to get rid of redundant checks

### DIFF
--- a/rehlds/engine/world.cpp
+++ b/rehlds/engine/world.cpp
@@ -1598,6 +1598,14 @@ void SV_ClipToLinks_Point(areanode_t* node, moveclip_t* clip)
 		if (clip->ignoretrans && touch->v.rendermode != kRenderNormal && !(touch->v.flags & FL_WORLDBRUSH))
 			continue;
 
+		if (clip->boxmins[0] > touch->v.absmax[0]
+			|| clip->boxmins[1] > touch->v.absmax[1]
+			|| clip->boxmins[2] > touch->v.absmax[2]
+			|| clip->boxmaxs[0] < touch->v.absmin[0]
+			|| clip->boxmaxs[1] < touch->v.absmin[1]
+			|| clip->boxmaxs[2] < touch->v.absmin[2])
+			continue;
+
 		if (clip->passedict && clip->passedict->v.size[0] && !touch->v.size[0])
 			continue; // points never interact
 

--- a/rehlds/engine/world.h
+++ b/rehlds/engine/world.h
@@ -113,4 +113,5 @@ trace_t SV_Move(const vec_t *start, const vec_t *mins, const vec_t *maxs, const 
 
 #ifdef REHLDS_OPT_PEDANTIC
 trace_t SV_Move_Point(const vec_t *start, const vec_t *end, int type, edict_t *passedict);
+void SV_ClipToLinks_Point(areanode_t* node, moveclip_t* clip);
 #endif // REHLDS_OPT_PEDANTIC


### PR DESCRIPTION
It looks like  `SV_CheckSphereIntersection` is redundant for a trace initiated by `SV_Move_Point`,  Maybe someone can confirm.