### PR TITLE
fix(filesystem): prevent crashing on certain systems on startup

### DIFF
--- a/rehlds/filesystem/FileSystem_Stdio/src/FileSystem_Stdio.cpp
+++ b/rehlds/filesystem/FileSystem_Stdio/src/FileSystem_Stdio.cpp
@@ -59,7 +59,7 @@ FILE *CFileSystem_Stdio::FS_fopen(const char *filename, const char *options, boo
 #ifndef _WIN32
 	if (!tst && !Q_strchr(options, 'w') && !Q_strchr(options, '+')) {
 		const char *file = findFileInDirCaseInsensitive(filename);
-		tst = fopen(filename, options);
+		tst = fopen(file, options);
 	}
 #endif // _WIN32
 


### PR DESCRIPTION
- get rid crashing GetSteamContentPath function
- enable use of pathmatching in CFileSystem_Stdio::FS_Open

Fixes #847 (also relevant https://github.com/ValveSoftware/halflife/issues/3158)