### PR TITLE
Improve pfnShouldCollide condition on SV_ClipToLinks

### DIFF
--- a/rehlds/engine/world.cpp
+++ b/rehlds/engine/world.cpp
@@ -1190,13 +1190,15 @@ void SV_ClipToLinks(areanode_t *node, moveclip_t *clip)
 		if (touch->v.solid == SOLID_TRIGGER)
 			Sys_Error("%s: Trigger in clipping list", __func__);
 
+#ifndef REHLDS_OPT_PEDANTIC
 		if (gNewDLLFunctions.pfnShouldCollide && !gNewDLLFunctions.pfnShouldCollide(touch, clip->passedict))
 #ifdef REHLDS_FIXES
 			// https://github.com/dreamstalker/rehlds/issues/46
 			continue;
 #else
 			return;
-#endif
+#endif // REHLDS_FIXES
+#endif // REHLDS_OPT_PEDANTIC
 
 		// monsterclip filter
 		if (touch->v.solid == SOLID_BSP)
@@ -1247,6 +1249,16 @@ void SV_ClipToLinks(areanode_t *node, moveclip_t *clip)
 			if (clip->passedict->v.owner == touch)
 				continue; // don't clip against owner
 		}
+
+#ifdef REHLDS_OPT_PEDANTIC
+		if (gNewDLLFunctions.pfnShouldCollide && !gNewDLLFunctions.pfnShouldCollide(touch, clip->passedict))
+#ifdef REHLDS_FIXES
+			// https://github.com/dreamstalker/rehlds/issues/46
+			continue;
+#else
+			return;
+#endif // REHLDS_FIXES
+#endif // REHLDS_OPT_PEDANTIC
 
 		trace_t trace;
 		if (touch->v.flags & FL_MONSTER)


### PR DESCRIPTION
Considered a heavy function, SV_ClipToLinks is called almost every frame where things "move". Since a fix done in the pfnShouldCollide function (#46) this function can be used safely, but in the context given, it wastes a lot of checks.

pfnShouldCollide is used by mods to filter entity collision from one to another, by allowing to NOT collide (but not to force collision), but just after this is called, some basic physics stuff is called to detect collision each other, having by result an useless call of pfnShouldCollide before. 

https://github.com/dreamstalker/rehlds/blob/de3679f0391f1452532c820f07a8c4042b1c4281/rehlds/engine/world.cpp#L1193-L1223

(like, checking they are far each other, why I'm checking collision on two distant entities?)

This PR moves pfnShouldCollide check after all the basic physics stuff, just to reduce function call inside plugins or submodules. There is no benefit in handling collisions in pfnShouldColide since subsequently there are conditions that will prevent their collision anyway.