### PR TITLE
Implemented reduction of impact caused by zip-bomb exploit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 <li>sv_rehlds_local_gametime <1|0> // A feature of local gametime which decrease "lags" if you run same map for a long time. Default: 0
 <li>sv_use_entity_file // Use custom entity file for a map. Path to an entity file will be "maps/[map name].ent". 0 - use original entities. 1 - use .ent files from maps directory. 2 - use .ent files from maps directory and create new .ent file if not exist.
 <li>sv_usercmd_custom_random_seed // When enabled server will populate an additional random seed independent of the client. Default: 0
+<li>sv_net_incoming_decompression <1|0> // When enabled server will decompress of incoming compressed file transfer payloads. Default: 1
+<li>sv_net_incoming_decompression_max_ratio <0|100> // Sets the max allowed ratio between compressed and uncompressed data for file transfer. (A ratio close to 90 indicates large uncompressed data with low entropy) Default: 80.0
+<li>sv_net_incoming_decompression_max_size <16|65536> // Sets the max allowed size for decompressed file transfer data. Default: 65536 bytes
 </ul>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 <li>sv_net_incoming_decompression <1|0> // When enabled server will decompress of incoming compressed file transfer payloads. Default: 1
 <li>sv_net_incoming_decompression_max_ratio <0|100> // Sets the max allowed ratio between compressed and uncompressed data for file transfer. (A ratio close to 90 indicates large uncompressed data with low entropy) Default: 80.0
 <li>sv_net_incoming_decompression_max_size <16|65536> // Sets the max allowed size for decompressed file transfer data. Default: 65536 bytes
+<li>sv_net_incoming_decompression_punish // Time in minutes for which the player will be banned for malformed/abnormal bzip2 fragments (0 - Permanent, use a negative number for a kick). Default: -1
 </ul>
 </details>
 

--- a/rehlds/engine/net_chan.cpp
+++ b/rehlds/engine/net_chan.cpp
@@ -1495,7 +1495,7 @@ qboolean Netchan_CopyNormalFragments(netchan_t *chan)
 				return FALSE;
 			}
 			// compressed data is expected only after requesting resource list
-			else if (host_client->m_sendrescount)
+			else if (host_client->m_sendrescount == 0)
 			{
 				Con_DPrintf("%s:Incoming compressed data disallowed from %s\n", NET_AdrToString(chan->remote_address), host_client->name);
 				return FALSE;

--- a/rehlds/engine/net_chan.cpp
+++ b/rehlds/engine/net_chan.cpp
@@ -1897,6 +1897,7 @@ void Netchan_Init(void)
 	Cvar_RegisterVariable(&sv_net_incoming_decompression);
 	Cvar_RegisterVariable(&sv_net_incoming_decompression_max_ratio);
 	Cvar_RegisterVariable(&sv_net_incoming_decompression_max_size);
+	Cvar_RegisterVariable(&sv_net_incoming_decompression_punish);
 #endif
 	Cvar_RegisterVariable(&sv_filetransfermaxsize);
 }


### PR DESCRIPTION
This PR enhance security by controlling the decompression of incoming network data buffer to avoid server hangs and another potential risks associated with zip bomb attacks.

Added network security CVars:
- `sv_net_incoming_decompression` (0-1) Enables or disables incoming data decompression. Default: 1
- `sv_net_incoming_decompression_max_ratio` (0.0 - 100.0) Sets max allowed ratio between compressed and decompressed data. (A ratio close to 90 indicates large uncompressed data with low entropy, this means abnormal compressed data which can cause server to hang). Default: 80
- `sv_net_incoming_decompression_max_size` (16-65536) Adjusts max size in bytes of output data after decompression. Default: 65536
- `sv_net_incoming_decompression_punish` Time in minutes for which the player will be banned for malformed/abnormal bzip2 fragments (0 - Permanent, use a negative number for a kick). Default: -1