### PR TITLE
engine: add sv_allow_autoaim cvar for HL25 DLL compatibility

### DIFF
--- a/rehlds/engine/pr_cmds.cpp
+++ b/rehlds/engine/pr_cmds.cpp
@@ -1802,7 +1802,14 @@ void EXT_FUNC PF_aim_I(edict_t *ent, float speed, float *rgflReturn)
 	bestdir[1] = dir[1];
 	bestdir[2] = dir[2];
 	bestdir[0] = dir[0];
-	bestdist = sv_aim.value;
+	if (sv_allow_autoaim.value)
+	{
+		bestdist = sv_aim.value;
+	}
+	else
+	{
+		bestdist = 0.0f;
+	}
 
 	for (int i = 1; i < g_psv.num_edicts; i++)
 	{

--- a/rehlds/engine/server.h
+++ b/rehlds/engine/server.h
@@ -283,6 +283,7 @@ extern rehlds_server_t g_rehlds_sv;
 extern cvar_t sv_lan;
 extern cvar_t sv_lan_rate;
 extern cvar_t sv_aim;
+extern cvar_t sv_allow_autoaim;
 
 extern cvar_t sv_skycolor_r;
 extern cvar_t sv_skycolor_g;

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -8025,7 +8025,9 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_visiblemaxplayers);
 	Cvar_RegisterVariable(&sv_password);
 	Cvar_RegisterVariable(&sv_aim);
+#ifdef REHLDS_FIXES
 	Cvar_RegisterVariable(&sv_allow_autoaim);
+#endif
 	Cvar_RegisterVariable(&violence_hblood);
 	Cvar_RegisterVariable(&violence_ablood);
 	Cvar_RegisterVariable(&violence_hgibs);

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -114,6 +114,7 @@ int giNextUserMsg = 64;
 cvar_t sv_lan = { "sv_lan", "0", 0, 0.0f, NULL };
 cvar_t sv_lan_rate = { "sv_lan_rate", "20000.0", 0, 0.0f, NULL };
 cvar_t sv_aim = { "sv_aim", "1", FCVAR_SERVER | FCVAR_ARCHIVE , 0.0f, NULL };
+cvar_t sv_allow_autoaim = { "sv_allow_autoaim", "1", FCVAR_SERVER | FCVAR_ARCHIVE, 0.0f, NULL };
 
 cvar_t sv_skycolor_r = { "sv_skycolor_r", "0", 0, 0.0f, NULL };
 cvar_t sv_skycolor_g = { "sv_skycolor_g", "0", 0, 0.0f, NULL };
@@ -8024,6 +8025,7 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_visiblemaxplayers);
 	Cvar_RegisterVariable(&sv_password);
 	Cvar_RegisterVariable(&sv_aim);
+	Cvar_RegisterVariable(&sv_allow_autoaim);
 	Cvar_RegisterVariable(&violence_hblood);
 	Cvar_RegisterVariable(&violence_ablood);
 	Cvar_RegisterVariable(&violence_hgibs);


### PR DESCRIPTION
Allows to work with HL25 server DLL, which acquires this new cvar and doesn't check against `nullptr`.

Was adding HL25 compatibility to Xash3D FWGS and decided to send this patch here too.