### PR TITLE
Increase engine limits in accordance to the new update

### DIFF
--- a/rehlds/common/qlimits.h
+++ b/rehlds/common/qlimits.h
@@ -39,6 +39,6 @@ constexpr auto MAX_LIGHTSTYLE_SIZE = size_t{64};
 #define MAX_BASE_DECALS			(1<<MAX_DECAL_INDEX_BITS)
 
 #define MAX_EVENTS			256
-#define MAX_PACKET_ENTITIES		256	// 256 visible entities per frame
+#define MAX_PACKET_ENTITIES		1024	// 1024 visible entities per frame
 
 #endif // QLIMITS_H

--- a/rehlds/engine/server.h
+++ b/rehlds/engine/server.h
@@ -31,7 +31,7 @@
 #include "maintypes.h"
 
 // TODO: I think this defines must be in /common/
-const int NUM_EDICTS = 900;
+const int NUM_EDICTS = 1200;
 const int MAX_NAME   = 32;
 
 #include "custom_int.h"


### PR DESCRIPTION
Increase packet entity limit for compatibility with the 25th anniversary update's maps (Primarily rocket_frenzy, at least that's the only one that caught my attention so far) in accordance to the limit present in the 25th anniversary update's engine.