### PR TITLE
Implement `HL25` new features

### DIFF
--- a/rehlds/engine/cmd.cpp
+++ b/rehlds/engine/cmd.cpp
@@ -1202,3 +1202,37 @@ void Cmd_CmdList_f(void)
 		Con_Printf("cmdlist logged to %s\n", szTemp);
 	}
 }
+
+void UnsafeCmdLineProcessor(const char *pchUnsafeCmdLine, int cubSize)
+{
+	int count = 9;
+	// mov edx, 6E6F632Bh
+	// mov ecx, 7463656Eh
+	const char* szPrefix = "nocmd tece ";
+	netadr_t *address;
+	char szSanitizedConnect[128];
+	
+	// 0x3039617A415A5F2D2E3A
+	// "09azAZ_-.:" ????
+
+	if(Q_strcmp(pchUnsafeCmdLine, szPrefix) == 0)
+	{
+		if (cubSize > count && pchUnsafeCmdLine[9] != ' ')
+		{
+			const char* address_str = &pchUnsafeCmdLine[9];
+
+			netadr_t address;
+			if (NET_StringToAdr(address_str, &address)) 
+			{
+				Q_snprintf(szSanitizedConnect, sizeof(szSanitizedConnect), "\nconnect %s\n", NET_AdrToString(address));
+				Cbuf_AddText(szSanitizedConnect);
+				Cbuf_AddText("\ncl_skipvid 1\n");
+				return;
+			} 
+
+			Con_Printf("Invalid address to connect to from unsafe location! Ignoring.\n");
+			return;
+		}
+	}
+	Con_Printf("Rejecting unsafe cmdline\n");
+}

--- a/rehlds/engine/cmd.h
+++ b/rehlds/engine/cmd.h
@@ -110,3 +110,4 @@ void Cmd_ForwardToServer(void);
 qboolean Cmd_ForwardToServerUnreliable(void);
 NOXREF int Cmd_CheckParm(const char *parm);
 void Cmd_CmdList_f(void);
+void UnsafeCmdLineProcessor(const char *pchUnsafeCmdLine, int cubSize);

--- a/rehlds/engine/sv_steam3.cpp
+++ b/rehlds/engine/sv_steam3.cpp
@@ -628,6 +628,34 @@ void CSteam3Client::OnGameOverlayActivated(GameOverlayActivated_t *pGameOverlayA
 #endif
 }
 
+void CSteam3Client::OnGameRichPresenceJoinRequested(GameRichPresenceJoinRequested_t *pGameRichPresenceJoinRequested)
+{
+	Con_Printf("OnGameRichPresenceJoinRequested\n");
+	
+	client_t* cl = CSteam3Client::ClientFindFromSteamID(pGameRichPresenceJoinRequested->m_steamIDFriend);
+	
+	if(cl)
+		UnsafeCmdLineProcessor(pGameRichPresenceJoinRequested->m_rgchConnect, k_cchMaxRichPresenceValueLength);
+}
+
+client_t *CSteam3Client::ClientFindFromSteamID(CSteamID &steamIDFind)
+{
+	for (int i = 0; i < g_psvs.maxclients; i++)
+	{
+		auto cl = &g_psvs.clients[i];
+		if (!cl->connected && !cl->active && !cl->spawned)
+			continue;
+
+		if (cl->network_userid.idtype != AUTH_IDTYPE_STEAM)
+			continue;
+
+		if (steamIDFind == cl->network_userid.m_SteamID)
+			return cl;
+	}
+
+	return NULL;
+}
+
 void CSteam3Client::RunFrame()
 {
 	CRehldsPlatformHolder::get()->SteamAPI_RunCallbacks();

--- a/rehlds/engine/sv_steam3.h
+++ b/rehlds/engine/sv_steam3.h
@@ -111,13 +111,17 @@ public:
 	STEAM_CALLBACK(CSteam3Client, OnClientGameServerDeny, ClientGameServerDeny_t, m_CallbackClientGameServerDeny);
 	STEAM_CALLBACK(CSteam3Client, OnGameServerChangeRequested, GameServerChangeRequested_t, m_CallbackGameServerChangeRequested);
 	STEAM_CALLBACK(CSteam3Client, OnGameOverlayActivated, GameOverlayActivated_t, m_CallbackGameOverlayActivated);
+	STEAM_CALLBACK(CSteam3Client, OnGameRichPresenceJoinRequested, GameRichPresenceJoinRequested_t, m_CallbackGameRichPresenceJoinRequested);
 
 	CSteam3Client() :
 		m_CallbackClientGameServerDeny(this, &CSteam3Client::OnClientGameServerDeny),
 		m_CallbackGameServerChangeRequested(this, &CSteam3Client::OnGameServerChangeRequested),
-		m_CallbackGameOverlayActivated(this, &CSteam3Client::OnGameOverlayActivated)
+		m_CallbackGameOverlayActivated(this, &CSteam3Client::OnGameOverlayActivated),
+		m_CallbackGameRichPresenceJoinRequested(this, &CSteam3Client::OnGameRichPresenceJoinRequested)
 	{}
-
+	
+	client_t *ClientFindFromSteamID(class CSteamID &steamIDFind);
+	
 	virtual void Shutdown();
 
 	int InitiateGameConnection(void *pData, int cbMaxData, uint64 steamID, uint32 unIPServer, uint16 usPortServer, bool bSecure);


### PR DESCRIPTION
Below there are some new functions Valve just added along with HL25 Update.

- [x] OnGameRichPresenceJoinRequested
- [x] UnsafeCmdLineProcessor ( Still needs tests )
- [ ] SetRichPresenceGameMode
- [ ] SetRichPresenceInfo

- [ ] SetRichPresenceOverride

- [ ] UpdateRichPresence

- [ ] SuckOutClassname

- [ ] NET_SendToImpl

- [ ] CSteam3Server::OnFakeIPResult + SteamNetworkingFakeIPResult_t struct

- [ ] NET_NetAdr_SetIP

- [ ] NET_NetAdr_SetPort

- [ ] NET_NetAdr_GetPort

- [ ] NET_NetAdr_GetIPNetworkByteOrder

- [ ] NET_NetAdr_GetIPHostByteOrder

- [ ] NET_CheckCleanupFakeIPConnection

- [ ] NET_IsSteamFakeIP

- [ ] NET_SteamFakeIPSendTo

- [ ] NET_SteamFakeIPRecvFrom
- [ ] NET_SteamFakeIPDestroySocket
- [ ] Net_CheckOpenFakeUDPPorts
- [ ] Net_CloseFakeUDPPorts
- [ ] Net_PollSteamFakeIPResult

I don't know if I will manage to finish every functionality, help is welcomed, also, ~it seems that valve implemented Anti UDP Proxy Forwarder. Good job from them~ nevermind, that SteamFakeIP is for anonymize the local game server.