### PR TITLE
Workflows: fix linux build(Action Checkout)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
     types: [published]
 
 env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   windows:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
   release:
     types: [published]
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true
+
 jobs:
   windows:
     name: 'Windows'


### PR DESCRIPTION
❌ /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found (required by /__e/node20/bin/node)