### PR TITLE
libsteam_api.so forward compat: finish VERSION_SAFE_STEAM_API_INTERFACES implementation

### DIFF
--- a/rehlds/engine/sv_steam3.h
+++ b/rehlds/engine/sv_steam3.h
@@ -77,6 +77,10 @@ protected:
 	char m_GameTagsData[MAX_STEAM_TAGS_LENGTH];
 #endif
 
+#ifdef VERSION_SAFE_STEAM_API_INTERFACES
+	CSteamGameServerAPIContext m_SteamGameServerAPIContext;
+#endif
+
 public:
 
 	NOBODY void SetServerType();
@@ -103,6 +107,10 @@ public:
 	void RunFrame();
 	void SendUpdatedServerDetails();
 	void UpdateGameTags();
+
+#ifdef VERSION_SAFE_STEAM_API_INTERFACES
+	CSteamGameServerAPIContext* GetSteamGameServerAPIContext();
+#endif
 };
 
 class CSteam3Client: public CSteam3
@@ -124,6 +132,15 @@ public:
 	void TerminateConnection(uint32, uint16);
 	void InitClient();
 	void RunFrame();
+
+#ifdef VERSION_SAFE_STEAM_API_INTERFACES
+	CSteamAPIContext* GetSteamAPIContext();
+#endif
+
+private:
+#ifdef VERSION_SAFE_STEAM_API_INTERFACES
+	CSteamAPIContext m_SteamAPIContext;
+#endif
 };
 
 extern CSteam3Server *s_Steam3Server;

--- a/rehlds/rehlds/platform.h
+++ b/rehlds/rehlds/platform.h
@@ -48,7 +48,11 @@ public:
 	virtual bool SteamAPI_Init() = 0;
 	virtual void SteamAPI_UnregisterCallResult(class CCallbackBase *pCallback, SteamAPICall_t hAPICall) = 0;
 	virtual ISteamApps* SteamApps() = 0;
+	#ifdef VERSION_SAFE_STEAM_API_INTERFACES
+	virtual bool SteamGameServer_InitSafe(uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString) = 0;
+	#else
 	virtual bool SteamGameServer_Init(uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString) = 0;
+	#endif
 	virtual ISteamGameServer* SteamGameServer() = 0;
 	virtual void SteamGameServer_RunCallbacks() = 0;
 	virtual void SteamAPI_RunCallbacks() = 0;
@@ -61,6 +65,11 @@ private:
 #ifdef _WIN32
 	setsockopt_proto setsockopt_v11;
 	HMODULE wsock;
+#endif
+
+#ifdef VERSION_SAFE_STEAM_API_INTERFACES
+	void* m_pGameServerContext;    // Actually CSteamGameServerAPIContext*
+	void* m_pClientContext;        // Actually CSteamAPIContext*
 #endif
 
 public:
@@ -105,7 +114,11 @@ public:
 	virtual bool SteamAPI_Init();
 	virtual void SteamAPI_UnregisterCallResult(class CCallbackBase *pCallback, SteamAPICall_t hAPICall);
 	virtual ISteamApps* SteamApps();
+	#ifdef VERSION_SAFE_STEAM_API_INTERFACES
+	virtual bool SteamGameServer_InitSafe(uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString);
+	#else
 	virtual bool SteamGameServer_Init(uint32 unIP, uint16 usSteamPort, uint16 usGamePort, uint16 usQueryPort, EServerMode eServerMode, const char *pchVersionString);
+	#endif
 	virtual ISteamGameServer* SteamGameServer();
 	virtual void SteamGameServer_RunCallbacks();
 	virtual void SteamAPI_RunCallbacks();

--- a/rehlds/rehlds/rehlds_interfaces_impl.cpp
+++ b/rehlds/rehlds/rehlds_interfaces_impl.cpp
@@ -905,7 +905,7 @@ IGameClient* GetRehldsApiClient(client_t* cl)
 }
 
 ISteamGameServer* EXT_FUNC CRehldsServerData::GetSteamGameServer() {
-	return ::SteamGameServer();
+	return CRehldsPlatformHolder::get()->SteamGameServer();
 }
 
 netadr_t* EXT_FUNC CRehldsServerData::GetNetFrom() {


### PR DESCRIPTION
## Purpose

This brings InitSafe compatibility with the libsteam_api.so. This should help future-proof as newer libs do not contain symbols for Init().

## Approach

Before this patch, VERSION_SAFE_STEAM_API_INTERFACES results in compile time errors and doesn't run.

This adds ifdef checks where Init() is used, replacing them with InitSafe() as [was already done in other files](https://github.com/rehlds/ReHLDS/blob/5f31306da5842b62736f1be16c0affc2a3c0c27f/rehlds/public/steam/steam_gameserver.h#L49). It properly uses, according to the comments, the CSteamAPIContext as stated in [rehlds/public/steam/steam_api.h](https://github.com/rehlds/ReHLDS/blob/5f31306da5842b62736f1be16c0affc2a3c0c27f/rehlds/public/steam/steam_api.h#L98)

#### Open Questions and Pre-Merge TODOs
- [ ] Additional longer-term playtesting

## Learning
I explored the headers to gain all this information and kept compiling until it worked. I used gdb to runtime errors. At first, I had compile-time type safety errors, which is how I ended up with the (void *) approach in sv_steam3.cpp, which works flawlessly.
