### PR TITLE
Fix MessageImpl::setParamString out-of-bounds write

### DIFF
--- a/rehlds/rehlds/rehlds_messagemngr_impl.cpp
+++ b/rehlds/rehlds/rehlds_messagemngr_impl.cpp
@@ -650,10 +650,11 @@ void MessageImpl::setParamString(size_t index, const char *value)
 	// Calculate the length of the string
 	Param_t &param = m_params[index];
 
+	size_t oldlen = param.newlen;
 	param.newlen = Q_strlen(value) + 1;
 
 	// Transform buffer to accommodate the new string length
-	setTxformBuffer(index, param.posBack, param.oldlen, param.newlen);
+	setTxformBuffer(index, param.posBack, oldlen, param.newlen);
 
 	// Copy the string value to the buffer
 	Q_memcpy(m_Storage[BACK].buf.data + param.posBack, value, param.newlen);


### PR DESCRIPTION
Calling setParamString twice can lead to memory access issues becasue a buffer with a wrong size is allocated.

For example when the new string is shorter than the original string:
First time, the buffer is correctly resized to a smaller size.
Second time, the the buffer is incorrectly resized AGAIN to even smaller size that now cannot hold the new string.

New behavior:
Compare the new string length to the current string length (not the original string length).