### PR TITLE
Engine: Fix save-restore crash (Win32)

### DIFF
--- a/rehlds/engine/sys_dll.cpp
+++ b/rehlds/engine/sys_dll.cpp
@@ -698,9 +698,9 @@ const char *FindAddressInTable(extensiondll_t *pDll, uint32 function)
 #ifdef _WIN32
 	for (int i = 0; i < pDll->functionCount; i++)
 	{
-		if (pDll[i].functionTable->pFunction == function)
+		if (pDll->functionTable[i].pFunction == function)
 		{
-			return pDll[i].functionTable->pFunctionName;
+			return pDll->functionTable[i].pFunctionName;
 		}
 	}
 #else // _WIN32
@@ -721,7 +721,7 @@ uint32 FindNameInTable(extensiondll_t *pDll, const char *pName)
 	{
 		if (!Q_strcmp(pName, pDll->functionTable[i].pFunctionName))
 		{
-			return pDll[i].functionTable->pFunction;
+			return pDll->functionTable[i].pFunction;
 		}
 	}
 	return NULL;
@@ -1440,3 +1440,4 @@ void EXT_FUNC Con_DPrintf(const char *fmt, ...)
 }
 
 #endif // defined(REHLDS_FIXES) and defined(REHLDS_FLIGHT_REC)
+


### PR DESCRIPTION
This PR fixes a crash which happens on changelevel (listen server) on Windows platform. Can't reproduce it in ReHLDS environment and it's not critical itself, however, I found that issue by replacing `FindAddressInTable`, `FindNameInTable` in client engine. So I just wanted to make sure these implementations will work correct on any platform and could be used as a reference in other projects.