### PR TITLE
Fix long-standing bug that makes voice mute affect multiple players

### DIFF
--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -2500,15 +2500,19 @@ void EXT_FUNC SV_ConnectClient_internal(void)
 	{
 		Con_DPrintf("Client %s connected\nAdr: %s\n", name, NET_AdrToString(host_client->netchan.remote_address));
 	}
-#ifndef REHLDS_OPT_PEDANTIC
+#if !defined(REHLDS_FIXES) && !defined(REHLDS_OPT_PEDANTIC)
 	Q_strncpy(host_client->hashedcdkey, cdkey, 32);
 	host_client->hashedcdkey[32] = '\0';
 #else
 	MD5Context_t ctx;
 	MD5Init(&ctx);
+#ifdef REHLDS_FIXES
+	MD5Update(&ctx, (unsigned char *)&host_client->network_userid.clientip, sizeof(unsigned int));
+#else
 	MD5Update(&ctx, (unsigned char *)cdkey, sizeof(cdkey));
+#endif // REHLDS_FIXES
 	MD5Final((unsigned char *)host_client->hashedcdkey, &ctx);
-#endif
+#endif // !defined(REHLDS_FIXES) && !defined(REHLDS_OPT_PEDANTIC)
 
 	host_client->active = FALSE;
 	host_client->spawned = FALSE;
@@ -4047,7 +4051,7 @@ void EXT_FUNC SV_WriteFullClientUpdate_internal(IGameClient *client, char *info,
 {
 	client_t* cl = client->GetClient();
 
-#ifndef REHLDS_OPT_PEDANTIC
+#if !defined(REHLDS_FIXES) && !defined(REHLDS_OPT_PEDANTIC)
 	unsigned char digest[16];
 
 	MD5Context_t ctx;
@@ -4061,7 +4065,7 @@ void EXT_FUNC SV_WriteFullClientUpdate_internal(IGameClient *client, char *info,
 	MSG_WriteLong(sb, cl->userid);
 	MSG_WriteString(sb, info);
 
-#ifndef REHLDS_OPT_PEDANTIC
+#if !defined(REHLDS_FIXES) && !defined(REHLDS_OPT_PEDANTIC)
 	MSG_WriteBuf(sb, sizeof(digest), digest);
 #else
 	MSG_WriteBuf(sb, 16, cl->hashedcdkey);


### PR DESCRIPTION
## Purpose
Fixes long-standing bug that makes client's voice mute affect multiple players.
https://github.com/ValveSoftware/halflife/issues/557

## Problem
The code used for voice muting is *very* old, dating back to the WON times. The hash of the client's CD key is used to keep a database of players that are muted by the user. This database is held on the client-side (voice_ban.dt).
After transition from WON to Steam, the cd keys weren't used anymore, but the mechanism remained (client->hashedcdkey), instead of taking a hash of the cdkey, now hash of the IP address is taken instead. The client takes hash of its *local* IP address, which wasn't a problem in the pre-NAT era, as people used to be connected straight to the internet and your local IP address was the same as your external IP address.
However, with NAT this mechanism breaks down. The user sends its local IP address as the cdkey, which is always something like 192.168.1.1 or 10.0.0.1, and many users share this local IP. Their "cdkey" hash ends up being the same, so now when you mute a player it will mute multiple players at the same time.

## Solution
To make the mechanism work like pre-NAT times, simply replace the hashedcdkey with the hash of the external IP address of the client. This will make the voice mute mechanism work again like it used to and clients have unique "cdkey" hashes.
